### PR TITLE
Fix proxy ws and other behavior

### DIFF
--- a/packages/standalone-proxy/index.ts
+++ b/packages/standalone-proxy/index.ts
@@ -7,6 +7,8 @@ import { getSSHKeys } from './src/ssh-keys'
 import url from 'url'
 import path from 'path'
 import { isProxyRequest, proxyHandlers } from './src/proxy'
+import { appLoggerFromEnv } from './src/logging'
+import pino from 'pino'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 
@@ -33,9 +35,9 @@ const envStore = inMemoryPreviewEnvStore({
   },
 })
 
-
-const app = createApp({ sshPublicKey, isProxyRequest: isProxyRequest(BASE_URL), proxyHandlers: proxyHandlers(envStore) })
-const sshLogger = app.log.child({ name: 'ssh_server' })
+const logger = pino(appLoggerFromEnv())
+const app = createApp({ sshPublicKey, isProxyRequest: isProxyRequest(BASE_URL), proxyHandlers: proxyHandlers({envStore, logger}), logger })
+const sshLogger = logger.child({ name: 'ssh_server' })
 
 const tunnelName = (clientId: string, remotePath: string) => {
   const serviceName = remotePath.replace(/^\//, '')

--- a/packages/standalone-proxy/src/logging.ts
+++ b/packages/standalone-proxy/src/logging.ts
@@ -1,6 +1,6 @@
-import { FastifyBaseLogger, FastifyLoggerOptions, PinoLoggerOptions } from 'fastify/types/logger'
+import { PinoLoggerOptions } from 'fastify/types/logger'
 
-const envToLogger: Record<string, (FastifyLoggerOptions & PinoLoggerOptions) | FastifyBaseLogger | false> = {
+const envToLogger: Record<string, PinoLoggerOptions> = {
   development: {
     level: process.env.DEBUG ? 'debug' : 'info',
     transport: {
@@ -13,8 +13,7 @@ const envToLogger: Record<string, (FastifyLoggerOptions & PinoLoggerOptions) | F
   },
   production: {
     level: process.env.DEBUG ? 'debug' : 'info',
-  },
-  test: false,
+  }
 }
 
 export const appLoggerFromEnv = () => envToLogger[process.env.NODE_ENV || 'development']


### PR DESCRIPTION
Fix #13, Grafana couldn't use websocket and also got weird errors in http requests. (project docker compose with Loki+Grafana)
The proxy didn't forward ws traffic as it require explicit forwarding of the ws socket. (using node-proxy `proxy.ws`)
Initially, I used the same approach and added websocket support to fastify and try to pass it to node-proxy, but it didn't work well.
Fastify offical proxy library is also incomplete.

End up using raw node.http handlers and rewiring it with fastify server factory.
All request with "preview" hosts (based on baseUrl) are skipping fastify handler pipeline.
  