### PR TITLE
Fix down command

### DIFF
--- a/packages/cli/src/commands/down/index.ts
+++ b/packages/cli/src/commands/down/index.ts
@@ -26,12 +26,14 @@ export default class Down extends DriverCommand<typeof Down> {
     const log = this.logger
     const { flags } = await this.parse(Down)
     const driver = await this.machineDriver()
-
-    const projectName = flags.project || await findAmbientProjectName(localComposeClient(flags.file))
-    log.debug(`project: ${projectName}`)
-    const envId = flags.id || await findAmbientEnvId(projectName)
-    log.debug(`envId: ${envId}`)
-
+    let envId = flags.id
+    if (!envId){
+      const projectName = flags.project || await findAmbientProjectName(localComposeClient(flags.file))
+      log.debug(`project: ${projectName}`)
+      envId = flags.id || await findAmbientEnvId(projectName)
+      log.debug(`envId: ${envId}`)
+    }
+    
     const machine = await driver.getMachine({ envId })
 
     if (!machine && !flags.force) {


### PR DESCRIPTION
If `id` is provided, use it and don't require project