### PR TITLE
Fix slow teardown because of telemetry

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,4 +26,7 @@
   "markdown.extension.toc.levels": "2..6",
   "prettier.enable": false,
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "[json]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
+  },
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,6 +69,9 @@
       ],
       "prerun": [
         "./dist/hooks/prerun/telemetry"
+      ],
+      "postrun": [
+        "./dist/hooks/postrun/telemetry"
       ]
     },
     "topicSeparator": " "

--- a/packages/cli/src/hooks/init/async-trace.ts
+++ b/packages/cli/src/hooks/init/async-trace.ts
@@ -1,7 +1,7 @@
 import ah from 'async_hooks'
 import { Hook } from '@oclif/core'
 
-const hook: Hook<'init'> = async () => {
+const hook: Hook.Init = async () => {
   const traces = new Map()
 
   const originalCaptureStackTrace = global.Error.captureStackTrace

--- a/packages/cli/src/hooks/init/sync-logging.ts
+++ b/packages/cli/src/hooks/init/sync-logging.ts
@@ -1,6 +1,6 @@
 import { Hook } from '@oclif/core'
 
-const hook: Hook<'init'> = async () => {
+const hook: Hook.Init = async () => {
   [process.stdout, process.stderr].forEach(stream => {
     if (stream?.isTTY) {
       // eslint-disable-next-line no-underscore-dangle

--- a/packages/cli/src/hooks/init/telemetry.ts
+++ b/packages/cli/src/hooks/init/telemetry.ts
@@ -1,7 +1,7 @@
 import { Hook } from '@oclif/core'
 import { createTelemetryEmitter, registerEmitter, wireProcessExit } from '@preevy/core'
 
-const hook: Hook<'init'> = async ({ config }) => {
+const hook: Hook.Init = async ({ config }) => {
   const disableTelemetry = config.scopedEnvVarTrue('DISABLE_TELEMETRY')
 
   if (disableTelemetry) {

--- a/packages/cli/src/hooks/postrun/telemetry.ts
+++ b/packages/cli/src/hooks/postrun/telemetry.ts
@@ -1,0 +1,14 @@
+import { Hook } from '@oclif/core'
+import { telemetryEmitter } from '@preevy/core'
+
+const hook: Hook.Postrun = async ({ config }) => {
+  const disableTelemetry = config.scopedEnvVarTrue('DISABLE_TELEMETRY')
+
+  if (disableTelemetry) {
+    return
+  }
+
+  telemetryEmitter().cancel()
+}
+
+export default hook

--- a/packages/cli/src/hooks/postrun/telemetry.ts
+++ b/packages/cli/src/hooks/postrun/telemetry.ts
@@ -1,14 +1,8 @@
 import { Hook } from '@oclif/core'
 import { telemetryEmitter } from '@preevy/core'
 
-const hook: Hook.Postrun = async ({ config }) => {
-  const disableTelemetry = config.scopedEnvVarTrue('DISABLE_TELEMETRY')
-
-  if (disableTelemetry) {
-    return
-  }
-
-  telemetryEmitter().cancel()
+const hook: Hook.Postrun = async () => {
+  void telemetryEmitter().flush()
 }
 
 export default hook

--- a/packages/cli/src/hooks/prerun/telemetry.ts
+++ b/packages/cli/src/hooks/prerun/telemetry.ts
@@ -1,7 +1,7 @@
 import { Hook } from '@oclif/core'
 import { telemetryEmitter } from '@preevy/core'
 
-const hook: Hook<'prerun'> = async ({ Command: command, argv }) => {
+const hook: Hook.Prerun = async ({ Command: command, argv }) => {
   telemetryEmitter().capture('run', {
     command: command.name,
     argv,

--- a/packages/compose-tunnel-agent/src/docker.ts
+++ b/packages/compose-tunnel-agent/src/docker.ts
@@ -1,5 +1,5 @@
 import Docker from 'dockerode'
-import { debounce } from 'lodash'
+import { throttle } from 'lodash'
 import { tryParseJson, Logger } from '@preevy/common'
 
 const composeFilter = {
@@ -40,15 +40,14 @@ const client = ({
   return {
     getRunningServices,
     startListening: async ({ onChange }: { onChange: (services: RunningService[]) => void }) => {
-      const handler = debounce(
+      const handler = throttle(
         async (data?: Buffer) => {
           log.debug('event handler: %j', data && tryParseJson(data.toString()))
 
           const services = await getRunningServices()
           onChange(services)
         },
-        debounceWait,
-        { leading: true }
+        debounceWait
       )
 
       const stream = await docker.getEvents({

--- a/packages/core/src/sftp-copy.ts
+++ b/packages/core/src/sftp-copy.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { debounce } from 'lodash'
+import { throttle } from 'lodash'
 import { ExpandedTransferProgress } from './ssh/client/progress-expanded'
 import { FileToCopy, SshClient } from './ssh/client'
 import { withSpinner } from './spinner'
@@ -44,7 +44,7 @@ export const copyFilesWithoutRecreatingDirUsingSftp = async (
     const sftp = await sshClient.sftp({ concurrency: 4 })
     try {
       const progress = await sftp.putFilesWithExpandedProgress(filesToCopyToTempDir, { chunkSize: 128 * 1024 })
-      progress.addListener(debounce((p: ExpandedTransferProgress) => { spinner.text = progressText(p) }, 100))
+      progress.addListener(throttle((p: ExpandedTransferProgress) => { spinner.text = progressText(p) }, 100))
       progress.addOneTimeListener(state => telemetryEmitter().capture('sftp copy start', { total_bytes: state.totalBytes, files: state.totalFiles }))
       await progress.done
       const doneProgress = await progress.current()

--- a/packages/core/src/telemetry/emitter.ts
+++ b/packages/core/src/telemetry/emitter.ts
@@ -122,7 +122,7 @@ export const telemetryEmitter = async ({ dataDir, version, debug }: {
     setProps: (props: TelemetryProperties) => {
       Object.assign(commonProperties, props)
     },
-    flush: async () => {
+    flush: () => {
       throttledFlush.cancel()
       return flush()
     },

--- a/packages/core/src/telemetry/emitter.ts
+++ b/packages/core/src/telemetry/emitter.ts
@@ -126,7 +126,6 @@ export const telemetryEmitter = async ({ dataDir, version, debug }: {
       throttledFlush.cancel()
       return flush()
     },
-    cancel: () => { throttledFlush.cancel() },
   })
 }
 
@@ -137,5 +136,4 @@ export const nullTelemetryEmitter: TelemetryEmitter = {
   capture: async () => undefined,
   setProps: () => undefined,
   flush: async () => undefined,
-  cancel: () => undefined,
 }


### PR DESCRIPTION
fixed #55 

There were 2 problems:
1. We used `debounced` while actually wanted to use `throttle`
2. We relied on Node's `exit` and `beforeExit` process events to cancel throttled flush events, but Node waits for all Promises to end before emitting those events, thus we wait for the `FLUSH_INTERVAL` which is set for eternity (i.e. 5 seconds)