### PR TITLE
fix typo in getting-started.mdx

### DIFF
--- a/site/docs/intro/getting-started.mdx
+++ b/site/docs/intro/getting-started.mdx
@@ -57,7 +57,7 @@ Preevy is designed to be easy to use, with an API smiliar to [docker-compose](ht
   preevy init
   ```
 
-4. From the same directory you run `docker comopse up` run:
+4. From the same directory you run `docker compose up` run:
 
   ```bash
   preevy up


### PR DESCRIPTION
fix typo from `docker comopse up` -> `docker compose up`