### PR TITLE
Fix/docs remove aws login

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You can read more about the story and philosophy behind Preevy [here](https://pr
 To start using the Preevy CLI you will need:
 
 - A local Cloud provider configuration context:
-  - In AWS, it could be by using `aws login` or `aws configure`
+  - In AWS, it could be by using `aws configure`
   - In GCP, it could be by using `gcloud auth application-default login`
 - A Docker-Compose application (examples can be found [here](https://github.com/docker/awesome-compose))
 

--- a/site/docs/intro/getting-started.mdx
+++ b/site/docs/intro/getting-started.mdx
@@ -46,11 +46,9 @@ Preevy is designed to be easy to use, with an API smiliar to [docker-compose](ht
   ```
 
 2. Choose the cloud provider you're going to use and configure credentials:
-   - For AWS: use `aws login` or `aws configure`. See [AWS lightsail credentials configurations](/drivers/aws-lightsail#credentials-configuration).
+   - For AWS: use `aws configure`. See [AWS lightsail credentials configurations](/drivers/aws-lightsail#credentials-configuration).
    - For GCP: use `gcloud auth application-default login`. See [GCP credentials configuration](/drivers/gcp-gce#credentials-configuration)
 
-  - In AWS, it could be by using `aws login` or `aws configure`
-  - In GCP, it could be by using 
 3. Set up a profile
 
   ```bash


### PR DESCRIPTION
This is continuation of the issue: README - aws login #74

- Removed the aws `login` command from another place in readme.
- Also fixed the text in docs to keep in sync with the readme.
- Removed redundant points in the docs.