### PR TITLE
baseUrl to rootUrl

### DIFF
--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -49,7 +49,7 @@ export default class Up extends MachineCreationDriverCommand<typeof Up> {
       insecureSkipVerify: flags['insecure-skip-verify'],
     }
 
-    const { hostKey, clientId, baseUrl } = await tunnelServerHello({
+    const { hostKey, clientId, rootUrl } = await tunnelServerHello({
       tunnelingKey,
       knownServerPublicKeys: pStore.knownServerPublicKeys,
       tunnelOpts,
@@ -62,7 +62,7 @@ export default class Up extends MachineCreationDriverCommand<typeof Up> {
 
     const { machine, tunnels, envId } = await commands.up({
       clientId,
-      baseUrl,
+      rootUrl,
       userSpecifiedServices: restArgs,
       debug: flags.debug,
       machineDriver: driver,

--- a/packages/cli/src/commands/urls.ts
+++ b/packages/cli/src/commands/urls.ts
@@ -44,7 +44,7 @@ export default class Urls extends ProfileCommand<typeof Urls> {
       insecureSkipVerify: flags['insecure-skip-verify'],
     }
 
-    const { clientId, baseUrl } = await tunnelServerHello({
+    const { clientId, rootUrl } = await tunnelServerHello({
       tunnelOpts,
       knownServerPublicKeys: pStore.knownServerPublicKeys,
       tunnelingKey: await pStore.getTunnelingKey(),
@@ -52,7 +52,7 @@ export default class Urls extends ProfileCommand<typeof Urls> {
     })
 
     const flatTunnels = await commands.urls({
-      baseUrl,
+      rootUrl,
       clientId,
       envId,
       projectName,

--- a/packages/cli/src/tunnel-server-client.ts
+++ b/packages/cli/src/tunnel-server-client.ts
@@ -37,7 +37,7 @@ export const tunnelServerHello = async ({ tunnelOpts, log, tunnelingKey, knownSe
   }
 
   return {
-    ...helloResponse as { baseUrl: string; clientId: string; hostKey: Buffer },
+    ...helloResponse,
     tunnelingKey,
   }
 }

--- a/packages/common/src/ssh/connection-checker.ts
+++ b/packages/common/src/ssh/connection-checker.ts
@@ -1,6 +1,6 @@
 import { baseSshClient, HelloResponse, SshClientOpts } from './base-client'
 
-export type ConnectionCheckResult = (Pick<HelloResponse, 'clientId' | 'baseUrl'> & { hostKey: Buffer }) | {
+export type ConnectionCheckResult = (Pick<HelloResponse, 'clientId' | 'rootUrl'> & { hostKey: Buffer }) | {
   error: Error
 } | {
   unverifiedHostKey: Buffer
@@ -23,7 +23,7 @@ export const checkConnection = ({
     ({ ssh, execHello }) => {
       execHello()
         .then(
-          ({ clientId, baseUrl }) => resolve({ clientId, hostKey, baseUrl }),
+          ({ clientId, rootUrl }) => resolve({ clientId, hostKey, rootUrl }),
           err => resolve({ error: err })
         )
         .finally(() => ssh.end())

--- a/packages/core/src/commands/up/index.ts
+++ b/packages/core/src/commands/up/index.ts
@@ -61,7 +61,7 @@ const serviceLinkEnvVars = (
 
 const up = async ({
   clientId,
-  baseUrl,
+  rootUrl,
   debug,
   machineDriver,
   machineCreationDriver,
@@ -80,7 +80,7 @@ const up = async ({
   skipUnchangedFiles,
 }: {
   clientId: string
-  baseUrl: string
+  rootUrl: string
   debug: boolean
   machineDriver: MachineDriver
   machineCreationDriver: MachineCreationDriver
@@ -107,7 +107,7 @@ const up = async ({
   // We start by getting the user model without injecting Preevy's environment
   // variables (e.g. `PREEVY_BASE_URI_BACKEND_3000`) so we can have the list of services
   // required to create said variables
-  const tunnelUrlForService = tunnelUrlForEnv({ projectName, envId, baseUrl: new URL(baseUrl), clientId })
+  const tunnelUrlForService = tunnelUrlForEnv({ projectName, envId, rootUrl: new URL(rootUrl), clientId })
   const composeEnv = { ...serviceLinkEnvVars(userModel, tunnelUrlForService) }
 
   const composeFiles = await resolveComposeFiles({

--- a/packages/core/src/commands/urls.ts
+++ b/packages/core/src/commands/urls.ts
@@ -1,14 +1,14 @@
 import { queryTunnels } from '../compose-tunnel-agent-client'
 import { flattenTunnels, tunnelUrlForEnv } from '../tunneling'
 
-export const urls = async ({ envId, baseUrl, clientId, projectName, serviceAndPort }: {
+export const urls = async ({ envId, rootUrl, clientId, projectName, serviceAndPort }: {
   envId: string
   projectName: string
-  baseUrl: string
+  rootUrl: string
   clientId: string
   serviceAndPort?: { service: string; port?: number }
 }) => {
-  const tunnelUrlForService = tunnelUrlForEnv({ projectName, envId, baseUrl: new URL(baseUrl), clientId })
+  const tunnelUrlForService = tunnelUrlForEnv({ projectName, envId, rootUrl: new URL(rootUrl), clientId })
 
   const { tunnels } = await queryTunnels({ tunnelUrlForService, retryOpts: { retries: 2 } })
 

--- a/tunnel-server/index.ts
+++ b/tunnel-server/index.ts
@@ -69,7 +69,7 @@ const sshServer = createSshServer({
   },
   onHello: (clientId, tunnels) => JSON.stringify({
     clientId,
-    // TODO: backwards compat, remove when we drop support for CLI v0.0.34
+    // TODO: backwards compat, remove when we drop support for CLI v0.0.35
     baseUrl: { hostname: BASE_URL.hostname, port: BASE_URL.port, protocol: BASE_URL.protocol },
     rootUrl: BASE_URL.toString(),
     tunnels: Object.fromEntries(tunnels.map(tunnel => [

--- a/tunnel-server/index.ts
+++ b/tunnel-server/index.ts
@@ -46,10 +46,10 @@ const tunnelName = (clientId: string, remotePath: string) => {
 }
 
 const tunnelUrl = (
-  baseUrl: URL,
+  rootUrl: URL,
   clientId: string,
   tunnel: string,
-) => replaceHostname(baseUrl, `${tunnelName(clientId, tunnel)}.${baseUrl.hostname}`).toString()
+) => replaceHostname(rootUrl, `${tunnelName(clientId, tunnel)}.${rootUrl.hostname}`).toString()
 
 const sshServer = createSshServer({
   log: sshLogger,
@@ -69,7 +69,9 @@ const sshServer = createSshServer({
   },
   onHello: (clientId, tunnels) => JSON.stringify({
     clientId,
-    baseUrl: BASE_URL.toString(),
+    // TODO: backwards compat, remove when we drop support for CLI v0.0.34
+    baseUrl: { hostname: BASE_URL.hostname, port: BASE_URL.port, protocol: BASE_URL.protocol },
+    rootUrl: BASE_URL.toString(),
     tunnels: Object.fromEntries(tunnels.map(tunnel => [
       tunnel,
       tunnelUrl(BASE_URL, clientId, tunnel),


### PR DESCRIPTION
replace `baseUrl` object returned from the `hello` command with `rootUrl` string, in a backwards-compatible way
