### PR TITLE
Add support for configuration of profile

### DIFF
--- a/packages/cli/src/commands/profile/config/update.ts
+++ b/packages/cli/src/commands/profile/config/update.ts
@@ -9,8 +9,8 @@ import {
   machineCreationflagsForAllDrivers,
   DriverName,
   machineDrivers
-} from '../../drivers'
-import ProfileCommand from '../../profile-command'
+} from '../../../drivers'
+import ProfileCommand from '../../../profile-command'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const removeDefaultFlagsDef = <T extends {[key: string]: Flag<any> } >(flags: T): T =>
@@ -21,7 +21,7 @@ const removeDefaultFlagsDef = <T extends {[key: string]: Flag<any> } >(flags: T)
   }) as T
 
 // eslint-disable-next-line no-use-before-define
-export default class ConfigureProfile extends ProfileCommand<typeof ConfigureProfile> {
+export default class UpdateProfileConfig extends ProfileCommand<typeof UpdateProfileConfig> {
   static description = 'View and update profile configuration'
 
   static flags = {

--- a/packages/cli/src/commands/profile/config/update.ts
+++ b/packages/cli/src/commands/profile/config/update.ts
@@ -8,7 +8,7 @@ import {
   flagsForAllDrivers,
   machineCreationflagsForAllDrivers,
   DriverName,
-  machineDrivers
+  machineDrivers,
 } from '../../../drivers'
 import ProfileCommand from '../../../profile-command'
 

--- a/packages/cli/src/commands/profile/config/view.ts
+++ b/packages/cli/src/commands/profile/config/view.ts
@@ -1,0 +1,23 @@
+import { profileStore } from '@preevy/core'
+import { ux } from '@oclif/core'
+import {
+  DriverName,
+} from '../../../drivers'
+import ProfileCommand from '../../../profile-command'
+
+// eslint-disable-next-line no-use-before-define
+export default class ViewProfileConfig extends ProfileCommand<typeof ViewProfileConfig> {
+  static description = 'View profile configuration'
+
+  static strict = false
+
+  static enableJsonFlag = true
+
+  async run(): Promise<void> {
+    const pStore = profileStore(this.store)
+    const driver = this.profile.driver as DriverName
+    const origin = await pStore.defaultFlags(driver)
+    ux.info(`Current configuration for ${driver}:`)
+    ux.styledObject(origin)
+  }
+}

--- a/packages/cli/src/commands/profile/configure.ts
+++ b/packages/cli/src/commands/profile/configure.ts
@@ -1,0 +1,72 @@
+import { profileStore } from '@preevy/core'
+import { Flags, ux } from '@oclif/core'
+import { Flag } from '@oclif/core/lib/interfaces'
+import { isEqual, mapValues, pickBy } from 'lodash'
+import {
+  stripDriverFlagNamePrefix,
+  extractConfigurableFlags,
+  flagsForAllDrivers,
+  machineCreationflagsForAllDrivers,
+  DriverName,
+  machineDrivers
+} from '../../drivers'
+import ProfileCommand from '../../profile-command'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const removeDefaultFlagsDef = <T extends {[key: string]: Flag<any> } >(flags: T): T =>
+  mapValues(flags, v => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { default: _, ...newV } = v
+    return newV
+  }) as T
+
+// eslint-disable-next-line no-use-before-define
+export default class ConfigureProfile extends ProfileCommand<typeof ConfigureProfile> {
+  static description = 'View and update profile configuration'
+
+  static flags = {
+    ...removeDefaultFlagsDef({
+      ...flagsForAllDrivers,
+      ...machineCreationflagsForAllDrivers,
+    }),
+    unset: Flags.string({
+      description: 'Unset a configuration option',
+      required: false,
+      multiple: true,
+    }),
+  }
+
+  static strict = false
+
+  static enableJsonFlag = true
+
+  async run(): Promise<void> {
+    const pStore = profileStore(this.store)
+    const driver = this.profile.driver as DriverName
+    const origin = await pStore.defaultFlags(driver)
+    let updated = origin
+    if (this.flags.unset) {
+      const allowedFlags = { ...machineDrivers[driver].flags, ...machineDrivers[driver].machineCreationFlags }
+      const stripped = (this.flags.unset ?? []).map(prefix => stripDriverFlagNamePrefix(driver, prefix))
+      for (const k of stripped) {
+        if (!(k in allowedFlags)) {
+          ux.error(`No such configuration option ${k}`, { exit: 1 })
+        }
+        // won't happen in practice, but we should address required flags in the future
+        if ((allowedFlags[k as keyof typeof allowedFlags] as Flag<unknown>).required) {
+          ux.error(`Cannot unset required configuration option ${k}`, { exit: 1 })
+          return
+        }
+      }
+      const prefixRemover = (k:string) => stripDriverFlagNamePrefix(driver, k)
+      updated = pickBy(updated, (_, k) => !this.flags.unset?.map(prefixRemover).includes(k))
+    }
+    updated = { ...updated, ...extractConfigurableFlags(this.flags, driver, { excludeDefaultValues: false }) }
+    if (!isEqual(origin, updated)) {
+      await pStore.setDefaultFlags(driver, updated)
+      ux.info('Updated profile configuration')
+    }
+    ux.info(`Current configuration for ${driver}:`)
+    ux.styledObject(updated)
+  }
+}


### PR DESCRIPTION
Fix #23 

Add the command `preevy profile configure`:

Usage examples:
```
# View current configuration
preevy profile config view ->

Current configuration for kube-pod:  
namespace:     test123
server-side-apply: false


# Update namespace for kube-pod driver
preevy profile config update --kube-pod-namespace=abc ->

Updated profile configuration
Current configuration for kube-pod:
namespace:     abc
server-side-apply: false


# Update namespace for kube-pod driver
preevy profile config update --unset=kube-pod-server-side-apply ->
# Or
preevy profile config update --unset=server-side-apply ->

Updated profile configuration
Current configuration for kube-pod:
namespace:     abc
```

