### PR TITLE
Allow to use the id param without compose when running preevy urls command

### DIFF
--- a/packages/cli/src/commands/urls.ts
+++ b/packages/cli/src/commands/urls.ts
@@ -32,10 +32,12 @@ export default class Urls extends ProfileCommand<typeof Urls> {
   async run(): Promise<unknown> {
     const log = this.logger
     const { flags, args } = await this.parse(Urls)
-    const projectName = (await this.ensureUserModel()).name
-    log.debug(`project: ${projectName}`)
-    const envId = flags.id || await findAmbientEnvId(projectName)
+    const [envId, projectName] = flags.id ? [flags.id, flags.id] : await (async () => {
+      const pname = (await this.ensureUserModel()).name
+      return [await findAmbientEnvId(pname), pname]
+    })()
     log.debug(`envId: ${envId}`)
+    log.debug(`project: ${projectName}`)
 
     const pStore = profileStore(this.store)
 


### PR DESCRIPTION
In similar fashion to down and to some degree, docker compose, allow users to get the URLs of the environments without the need to specify the compose files or project name.

Currently, the resolver already uses the envId in this flow:
```
const resolver = tunnelNameResolver({ userDefinedSuffix: envId })
```
So, the behavior should be consistent