### PR TITLE
make compose tunnel agent tunnel private

### DIFF
--- a/.github/workflows/npm-publish-canary.yaml
+++ b/.github/workflows/npm-publish-canary.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish-packages:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.owner.name == 'livecycle'
 
     steps:
     - uses: actions/checkout@v3

--- a/packages/cli-common/src/lib/hooks.ts
+++ b/packages/cli-common/src/lib/hooks.ts
@@ -2,12 +2,16 @@ import { ComposeModel, FlatTunnel } from '@preevy/core'
 import { PluginContext } from './plugins/context'
 
 export type Hooks = {
+  filterUrls: {
+    args: FlatTunnel[]
+    return: FlatTunnel[]
+  }
   envCreated: {
     args: {
       envId: string
       urls: FlatTunnel[]
     }
-    return: { urls: FlatTunnel[] }
+    return: void
   }
   envDeleted: {
     args: {

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -2,7 +2,6 @@ import { Args, Flags, ux } from '@oclif/core'
 import {
   commands, flattenTunnels, profileStore,
   telemetryEmitter,
-  getUserCredentials, jwtGenerator, withBasicAuthCredentials,
 } from '@preevy/core'
 import { asyncReduce } from 'iter-tools-es'
 import { tunnelServerFlags } from '@preevy/cli-common'
@@ -81,13 +80,11 @@ export default class Up extends MachineCreationDriverCommand<typeof Up> {
       allowedSshHostKeys: hostKey,
       cwd: process.cwd(),
       skipUnchangedFiles: flags['skip-unchanged-files'],
+      tunnelingKey,
+      includeAccessCredentials: flags['include-access-credentials'],
     })
 
-    let flatTunnels = flattenTunnels(tunnels)
-    if (flags['include-access-credentials']) {
-      const addCredentials = withBasicAuthCredentials(await getUserCredentials(jwtGenerator(tunnelingKey)))
-      flatTunnels = flatTunnels.map(t => Object.assign(t, { url: addCredentials(t.url) }))
-    }
+    const flatTunnels = flattenTunnels(tunnels)
 
     const result = await asyncReduce(
       { urls: flatTunnels },
@@ -103,8 +100,6 @@ export default class Up extends MachineCreationDriverCommand<typeof Up> {
     }
 
     this.log(`Preview environment ${envId} provisioned at: ${machine.locationDescription}`)
-
-    // add credentials here
 
     ux.table(
       result.urls,

--- a/packages/cli/src/commands/urls.ts
+++ b/packages/cli/src/commands/urls.ts
@@ -1,5 +1,5 @@
 import { Args, ux } from '@oclif/core'
-import { commands, findAmbientEnvId, getUserCredentials, jwtGenerator, profileStore, withBasicAuthCredentials } from '@preevy/core'
+import { commands, findAmbientEnvId, profileStore } from '@preevy/core'
 import { tunnelServerFlags } from '@preevy/cli-common'
 import { tunnelServerHello } from '../tunnel-server-client'
 import ProfileCommand from '../profile-command'
@@ -51,17 +51,14 @@ export default class Urls extends ProfileCommand<typeof Urls> {
       log: this.logger,
     })
 
-    let flatTunnels = await commands.urls({
+    const flatTunnels = await commands.urls({
       rootUrl,
       clientId,
       envId,
       serviceAndPort: args.service ? { service: args.service, port: args.port } : undefined,
+      tunnelingKey,
+      includeAccessCredentials: flags['include-access-credentials'],
     })
-
-    if (flags['include-access-credentials']) {
-      const addCredentials = withBasicAuthCredentials(await getUserCredentials(jwtGenerator(tunnelingKey)))
-      flatTunnels = flatTunnels.map(t => Object.assign(t, { url: addCredentials(t.url) }))
-    }
 
     if (flags.json) {
       return flatTunnels

--- a/packages/cli/src/commands/urls.ts
+++ b/packages/cli/src/commands/urls.ts
@@ -32,9 +32,7 @@ export default class Urls extends ProfileCommand<typeof Urls> {
   async run(): Promise<unknown> {
     const log = this.logger
     const { flags, args } = await this.parse(Urls)
-    const projectName = (await this.ensureUserModel()).name
-    log.debug(`project: ${projectName}`)
-    const envId = flags.id || await findAmbientEnvId(projectName)
+    const envId = flags.id || await findAmbientEnvId((await this.ensureUserModel()).name)
     log.debug(`envId: ${envId}`)
 
     const pStore = profileStore(this.store)
@@ -57,7 +55,6 @@ export default class Urls extends ProfileCommand<typeof Urls> {
       rootUrl,
       clientId,
       envId,
-      projectName,
       serviceAndPort: args.service ? { service: args.service, port: args.port } : undefined,
     })
 

--- a/packages/common/src/tunnel-name.ts
+++ b/packages/common/src/tunnel-name.ts
@@ -1,5 +1,4 @@
-const concat = (...v: (string | number)[]) => v.join('-')
-const tunnel = (port: number, v: (string | number)[]) => ({ port, tunnel: concat(...v).toLowerCase() })
+const tunnel = (port: number, v: (string | number)[]) => ({ port, tunnel: v.join('-').toLowerCase() })
 
 export type TunnelNameResolver = (x: {
   name: string

--- a/packages/compose-tunnel-agent/src/ssh/tunnel-client.ts
+++ b/packages/compose-tunnel-agent/src/ssh/tunnel-client.ts
@@ -15,7 +15,7 @@ type Forward = {
 export type Tunnel = {
   project: string
   service: string
-  ports: Record<number, string[]>
+  ports: Record<number, string>
 }
 
 export type SshState = {
@@ -121,7 +121,7 @@ export const sshClient = async ({
             service: service.name,
             project: service.project,
             ports: {},
-          }).ports[port] ||= []).push(url)
+          }).ports[port] = url)
           return res
         },
         {} as Record<string, Tunnel>,

--- a/packages/core/src/commands/up/index.ts
+++ b/packages/core/src/commands/up/index.ts
@@ -109,7 +109,7 @@ const up = async ({
   // We start by getting the user model without injecting Preevy's environment
   // variables (e.g. `PREEVY_BASE_URI_BACKEND_3000`) so we can have the list of services
   // required to create said variables
-  const tunnelUrlsForService = tunnelUrlsForEnv({ projectName, envId, rootUrl: new URL(rootUrl), clientId })
+  const tunnelUrlsForService = tunnelUrlsForEnv({ envId, rootUrl: new URL(rootUrl), clientId })
   const composeEnv = { ...serviceLinkEnvVars(userModel, tunnelUrlsForService) }
 
   const composeFiles = await resolveComposeFiles({

--- a/packages/core/src/commands/urls.ts
+++ b/packages/core/src/commands/urls.ts
@@ -2,14 +2,13 @@ import { queryTunnels } from '../compose-tunnel-agent-client'
 import { flattenTunnels, tunnelUrlsForEnv } from '../tunneling'
 
 export const urls = async ({ envId,
-  rootUrl, clientId, projectName, serviceAndPort }: {
+  rootUrl, clientId, serviceAndPort }: {
   envId: string
-  projectName: string
   rootUrl: string
   clientId: string
   serviceAndPort?: { service: string; port?: number }
 }) => {
-  const tunnelUrlsForService = tunnelUrlsForEnv({ projectName, envId, rootUrl: new URL(rootUrl), clientId })
+  const tunnelUrlsForService = tunnelUrlsForEnv({ envId, rootUrl: new URL(rootUrl), clientId })
 
   const { tunnels } = await queryTunnels({ tunnelUrlsForService, retryOpts: { retries: 2 } })
 

--- a/packages/core/src/compose/model.ts
+++ b/packages/core/src/compose/model.ts
@@ -50,6 +50,7 @@ export type ComposeService = {
   ports?: ComposePort[]
   environment?: Record<string, string | undefined> | EnvString[]
   user?: string
+  labels?: Record<string, string> | `${string}=${string}`[]
 }
 
 export type ComposeModel = {

--- a/packages/core/src/credentials/index.ts
+++ b/packages/core/src/credentials/index.ts
@@ -25,8 +25,8 @@ export const jwtGenerator = (privateKey: string | Buffer) => {
   }
   const key = createPrivateKey(sshKey.getPrivatePEM())
   const alg = getAsymmetricKeyAlg(key)
-  const thumbprint = memoize(async () =>
-    await calculateJwkThumbprintUri(await exportJWK(key)))
+  const thumbprint = memoize(async () => await calculateJwkThumbprintUri(await exportJWK(key)))
+
   return async ({ claims = {}, exp = '60d' }: {claims?:JWTPayload; exp?: string} = {}) => await (new SignJWT(claims).setProtectedHeader({ alg })
     .setIssuedAt()
     .setIssuer(`preevy://${await thumbprint()}`)
@@ -36,8 +36,7 @@ export const jwtGenerator = (privateKey: string | Buffer) => {
 
 export type JwtGenerator = ReturnType<typeof jwtGenerator>
 
-export const generateBasicAuthCredentials = async (jwtGen: JwtGenerator) =>
-  ({
-    user: 'x-preevy-profile-key',
-    password: await jwtGen(),
-  })
+export const generateBasicAuthCredentials = async (jwtGen: JwtGenerator) => ({
+  user: 'x-preevy-profile-key',
+  password: await jwtGen(),
+})

--- a/packages/core/src/tunneling/index.ts
+++ b/packages/core/src/tunneling/index.ts
@@ -110,8 +110,7 @@ export const performTunnelConnectionCheck = async ({
 export const createTunnelingKey = async () => Buffer.from((await generateSshKeyPair()).privateKey)
 
 export const tunnelUrlsForEnv = (
-  { projectName, envId, rootUrl, clientId }: {
-    projectName: string
+  { envId, rootUrl, clientId }: {
     envId: string
     rootUrl: URL
     clientId: string
@@ -119,7 +118,7 @@ export const tunnelUrlsForEnv = (
 ) => {
   const resolver = tunnelNameResolver({ userDefinedSuffix: envId })
   return ({ name: serviceName, ports: servicePorts }: { name: string; ports: number[] }) => {
-    const tunnels = resolver({ name: serviceName, project: projectName, ports: servicePorts })
+    const tunnels = resolver({ name: serviceName, project: '', ports: servicePorts })
     return tunnels.map(({ port, tunnel }) => ({ port, url: replaceHostname(rootUrl, `${tunnel}-${clientId}.${rootUrl.hostname}`).toString() }))
   }
 }

--- a/packages/core/src/tunneling/index.ts
+++ b/packages/core/src/tunneling/index.ts
@@ -9,7 +9,7 @@ type url = string
 export type Tunnel = {
   project: string
   service: string
-  ports: Record<port, url[]>
+  ports: Record<port, url>
 }
 
 export type FlatTunnel = {
@@ -22,12 +22,12 @@ export type FlatTunnel = {
 export const flattenTunnels = (
   tunnels: Tunnel[],
 ): FlatTunnel[] => tunnels
-  .map(t => Object.entries(t.ports).map(([port, urls]) => urls.map(url => ({
+  .map(t => Object.entries(t.ports).map(([port, url]) => ({
     project: t.project,
     service: t.service,
     port: Number(port),
     url,
-  }))))
+  })))
   .flat(2)
 
 export class UnverifiedHostKeyError extends Error {

--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -1,5 +1,6 @@
-export const withBasicAuthCredentials = ({ user, password }:{user: string; password: string}) =>
-  (url:string) => Object.assign(new URL(url), {
-    username: user,
-    password,
-  }).toString()
+export const withBasicAuthCredentials = (
+  { user, password } : { user: string; password: string },
+) => (url: string) => Object.assign(new URL(url), {
+  username: user,
+  password,
+}).toString()

--- a/packages/plugin-github-pr-link/src/hooks.ts
+++ b/packages/plugin-github-pr-link/src/hooks.ts
@@ -39,7 +39,6 @@ export const envCreated = ({ argv, pluginConfig, oclifConfig }: {
   oclifConfig: OclifConfig
 }): HookFunc<'envCreated'> => async ({ log }, { envId, urls }) => {
   await hook({ argv, pluginConfig, oclifConfig, log, envId, content: { urls } })
-  return { urls }
 }
 
 export const envDeleted = ({ argv, pluginConfig, oclifConfig }: {

--- a/tunnel-server/src/ssh-server.ts
+++ b/tunnel-server/src/ssh-server.ts
@@ -2,7 +2,7 @@ import crypto, { randomBytes } from 'crypto'
 import { FastifyBaseLogger } from 'fastify/types/logger'
 import net from 'net'
 import path from 'path'
-import ssh2, { ParsedKey, SocketBindInfo } from 'ssh2'
+import ssh2, { Client, ParsedKey, SocketBindInfo } from 'ssh2'
 import { inspect } from 'util'
 import { ForwardRequest, parseForwardRequest } from './forward-request'
 import EventEmitter from 'node:events'
@@ -96,10 +96,9 @@ export const sshServer = (
     },
     client => {
       let preevySshClient: SshClient
-      const tunnels = new Map<string, { close: () => void }>()
+      const socketServers = new Map<string, net.Server>()
 
       client
-        .on('error', err => log.error(`client error: %j`, inspect(err)))
         .on('authentication', (ctx) => {
           log.debug('authentication: %j', ctx)
           if (ctx.method !== 'publickey') {
@@ -140,14 +139,14 @@ export const sshServer = (
 
           if ((name as string) == 'cancel-streamlocal-forward@openssh.com') {
             const request = forwardRequestFromSocketBindInfo(info as unknown as SocketBindInfo)
-            const deleted = tunnels.get(request)
+            const deleted = socketServers.get(request)
             if (!deleted) {
               log.error('cancel-streamlocal-forward@openssh.com: request %j not found, rejecting', request)
               reject?.()
               return
             }
+            deleted.once('close', () => { accept?.() })
             deleted.close()
-            accept?.()
             return
           }
 
@@ -167,7 +166,7 @@ export const sshServer = (
 
           const { parsed } = res
 
-          if (tunnels.has(request)) {
+          if (socketServers.has(request)) {
             log.error('streamlocal-forward@openssh.com: rejecting %j, duplicate socket request', request)
             reject?.()
             return
@@ -204,7 +203,7 @@ export const sshServer = (
                 .listen(socketPath, () => {
                   log.debug('streamlocal-forward@openssh.com: request %j calling accept: %j', request, accept)
                   accept?.()
-                  tunnels.set(request, socketServer)
+                  socketServers.set(request, socketServer)
                   resolveForward(Object.assign(socketServer, { localSocketPath: socketPath }))
                 })
                 .on('error', (err: unknown) => {
@@ -214,7 +213,7 @@ export const sshServer = (
                 })
                 .on('close', () => {
                   log.debug('socketServer close: %j', socketPath)
-                  tunnels.delete(request)
+                  socketServers.delete(request)
                   client.removeListener('close', closeSocketServer)
                 })
 
@@ -227,7 +226,10 @@ export const sshServer = (
           )
 
         })
-        .on('error', err => { preevySshClient.emit('error', err) })
+        .on('error', err => {
+          log.error(`client error: %j`, inspect(err))
+          preevySshClient?.emit('error', err)
+        })
         .on('session', accept => {
           log.debug('session')
           const session = accept()
@@ -245,17 +247,11 @@ export const sshServer = (
               stdout: channel.stdout,
               exit: (status: number) => {
                 channel.stdout.exit(status)
-                if (tunnels.size === 0) {
+                if (socketServers.size === 0) {
                   channel.close()
                 }
               },
             })
-            // channel.stdout.on('close', () => {
-            //   log.debug('hello close, tunnels: %d', tunnels.size)
-            //   if (tunnels.size === 0) {
-            //     channel.close()
-            //   }
-            // })
           })
         })
     }


### PR DESCRIPTION
also contains:

- refactor `projectName` out of `queryTunnels` so the `urls` command would not need a compose file
- fix for bug in tunnel server manifesting when upgrading the compose tunnel agent tunnel access