### PR TITLE
fix ls showing other resources

### DIFF
--- a/packages/core/src/commands/ls.ts
+++ b/packages/core/src/commands/ls.ts
@@ -6,6 +6,6 @@ const ls = async ({
 }: {
   machineDriver: MachineDriver
   log: Logger
-}) => machineDriver.listDeletableResources()
+}) => machineDriver.listMachines()
 
 export default ls

--- a/packages/core/src/driver/driver.ts
+++ b/packages/core/src/driver/driver.ts
@@ -40,6 +40,7 @@ export type MachineDriver<
     stdio: PartialStdioOptions,
   ) => Promise<{ code: number } | { signal: string }>
 
+  listMachines: () => AsyncIterableIterator<Machine | PartialMachine>
   listDeletableResources: () => AsyncIterableIterator<Resource<ResourceType>>
   deleteResources: (wait: boolean, ...resource: Resource<string>[]) => Promise<void>
   machineStatusCommand: (machine: MachineBase) => Promise<MachineStatusCommand | undefined>

--- a/packages/driver-gce/src/driver/index.ts
+++ b/packages/driver-gce/src/driver/index.ts
@@ -50,32 +50,34 @@ const machineFromInstance = (
   }
 }
 
-const machineDriver = (
-  { store, client }: DriverContext,
-): MachineDriver<SshMachine, ResourceType> => ({
-  friendlyName: 'Google Cloud',
+const machineDriver = ({ store, client }: DriverContext): MachineDriver<SshMachine, ResourceType> => {
+  const listMachines = () => asyncMap(machineFromInstance, client.listInstances())
 
-  getMachine: async ({ envId }) => {
-    const instance = await client.findInstance(envId)
-    return instance && machineFromInstance(instance)
-  },
+  return ({
+    friendlyName: 'Google Cloud',
 
-  listDeletableResources: () => asyncMap(machineFromInstance, client.listInstances()),
-  deleteResources: async (wait, ...resources) => {
-    await Promise.all(resources.map(({ type, providerId }) => {
-      if (type === 'machine') {
-        return client.deleteInstance(providerId, wait)
-      }
-      throw new Error(`Unknown resource type: "${type}"`)
-    }))
-  },
+    getMachine: async ({ envId }) => {
+      const instance = await client.findInstance(envId)
+      return instance && machineFromInstance(instance)
+    },
 
-  resourcePlurals: {},
+    listMachines,
+    listDeletableResources: listMachines,
 
-  ...sshDriver({ getSshKey: () => getStoredSshKey(store, SSH_KEYPAIR_ALIAS) }),
+    deleteResources: async (wait, ...resources) => {
+      await Promise.all(resources.map(({ type, providerId }) => {
+        if (type === 'machine') {
+          return client.deleteInstance(providerId, wait)
+        }
+        throw new Error(`Unknown resource type: "${type}"`)
+      }))
+    },
 
-  machineStatusCommand: async () => machineStatusNodeExporterCommand,
-})
+    resourcePlurals: {},
+    ...sshDriver({ getSshKey: () => getStoredSshKey(store, SSH_KEYPAIR_ALIAS) }),
+    machineStatusCommand: async () => machineStatusNodeExporterCommand,
+  })
+}
 
 const flags = {
   'project-id': Flags.string({

--- a/packages/driver-lightsail/src/driver/index.ts
+++ b/packages/driver-lightsail/src/driver/index.ts
@@ -48,6 +48,8 @@ const machineDriver = ({
 }: DriverContext): MachineDriver<SshMachine, ResourceType> => {
   const keyAlias = region
 
+  const listMachines = () => asyncMap(machineFromInstance, client.listInstances())
+
   return {
     friendlyName: 'AWS Lightsail',
     customizationScripts: CUSTOMIZE_BARE_MACHINE,
@@ -57,11 +59,9 @@ const machineDriver = ({
       return instance && machineFromInstance(instance)
     },
 
+    listMachines,
     listDeletableResources: () => {
-      const machines = asyncMap(
-        machineFromInstance,
-        client.listInstances(),
-      )
+      const machines = listMachines()
 
       const snapshots = asyncMap(
         ({ name }) => ({ type: 'snapshot' as ResourceType, providerId: name as string }),


### PR DESCRIPTION
fixes #159

add `listMachines` in drivers, in addition to `listDeletableResources`

`listMachines` is used by the `ls` command
`listDeletableResources` is used by the `purge` command

For drivers with only machine resources (all but AWS) the two functions are identical. Most of the diff is layout changes due to extracting `listMachines` and using it in two places.

<!-- Thank you for your interest in contributing to Preevy! 🎉 -->

<!-- Please fill in the below placeholders -->

**[Is this a bugfix/feature/doc-improvement?]**
## This is a

- [X] Bug fix
- [ ] Feature
- [ ] Doc improvement

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

- [X] I have used Preevy for a while and am familiar with the function it providers.

If this is a bug fix or feature:

- [X] I tested the proposed change on my cloud provider: AWS
- [X] I tested the proposed change on a local Kubernetes cluster.

