### PR TITLE
kube driver: fix sanitation of names

### DIFF
--- a/packages/driver-kube-pod/src/driver/client/labels.ts
+++ b/packages/driver-kube-pod/src/driver/client/labels.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from 'crypto'
 import { mapValues } from 'lodash'
 import { truncateWithHash } from '@preevy/core'
 
@@ -12,14 +11,3 @@ export const sanitizeLabel = (s: string) => truncateWithHash(
 )
 
 export const sanitizeLabels = <T extends Record<string, string>>(labels: T) => mapValues(labels, sanitizeLabel) as T
-
-const truncatePrefixToMaxLength = (prefix: string, suffix: string, spareLength = 0) => {
-  const maxPrefixLength = MAX_LABEL_LENGTH - suffix.length - 1 - spareLength
-  return [prefix.substring(0, maxPrefixLength), suffix].join('-')
-}
-
-export const labelWithRandomSuffix = (s: string[], spareLength = 0) => {
-  const prefix = s.map(sanitizeLabel).join('-')
-  const suffix = sanitizeLabel(randomBytes(8).toString('base64url').toLowerCase())
-  return truncatePrefixToMaxLength(prefix, suffix, spareLength)
-}

--- a/packages/driver-kube-pod/src/driver/client/metadata.ts
+++ b/packages/driver-kube-pod/src/driver/client/metadata.ts
@@ -1,6 +1,7 @@
+import { randomBytes } from 'crypto'
 import * as k8s from '@kubernetes/client-node'
-import { extractDefined } from '@preevy/core'
-import { labelWithRandomSuffix, sanitizeLabel, sanitizeLabels } from './labels'
+import { extractDefined, truncateWithHash } from '@preevy/core'
+import { sanitizeLabel, sanitizeLabels } from './labels'
 import { HasMetadata, Package } from './common'
 
 export const MAX_LABEL_LENGTH = 63
@@ -129,8 +130,30 @@ export const profileSelector = ({ profileId }: { profileId: string }) => ({
 export const isDockerHostDeployment = (s: k8s.KubernetesObject) => s.kind === 'Deployment'
     && s.metadata?.labels?.[LABELS.COMPONENT] === DOCKER_HOST_VALUE
 
+const MAX_NAME_LENGTH = 63
+
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+const sanitizeName = (s: string) => truncateWithHash(
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/^[^a-z0-9]/, ''), // remove first char if it is not alphanumeric
+  MAX_NAME_LENGTH,
+)
+
+const truncatePrefixToMaxLength = (prefix: string, suffix: string, spareLength = 0) => {
+  const maxPrefixLength = MAX_NAME_LENGTH - suffix.length - 1 - spareLength
+  return [prefix.substring(0, maxPrefixLength), suffix].join('-')
+}
+
+const nameWithRandomSuffix = (s: string[], spareLength = 0) => {
+  const prefix = sanitizeName(s.join('-'))
+  const suffix = sanitizeName(randomBytes(5).toString('base64url'))
+  return truncatePrefixToMaxLength(prefix, suffix, spareLength)
+}
+
 const RANDOM_ID_SPARE_LENGTH = 10
 
 export const envRandomId = (
   { envId, profileId }: { envId: string; profileId: string },
-) => labelWithRandomSuffix([profileId, envId], RANDOM_ID_SPARE_LENGTH)
+) => nameWithRandomSuffix([profileId, envId], RANDOM_ID_SPARE_LENGTH)


### PR DESCRIPTION
underscores are not supported according to doc: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
