### PR TITLE
gce: fix labels

### DIFF
--- a/packages/driver-gce/src/driver/index.ts
+++ b/packages/driver-gce/src/driver/index.ts
@@ -12,10 +12,12 @@ import {
   machineResourceType,
   Logger,
   machineStatusNodeExporterCommand,
+  extractDefined,
 } from '@preevy/core'
 import { pick } from 'lodash'
 import createClient, { Client, Instance, availableRegions, defaultProjectId, shortResourceName } from './client'
 import { deserializeMetadata, metadataKey } from './metadata'
+import { LABELS } from './labels'
 
 type DriverContext = {
   log: Logger
@@ -31,6 +33,13 @@ const SSH_USERNAME = 'preevy'
 
 const DEFAULT_MACHINE_TYPE = 'e2-small'
 
+const envIdFromInstance = ({ metadata, labels }: Pick<Instance, 'metadata' | 'labels'>) => {
+  const metadataItemValue = metadata?.items?.find(({ key }) => key === metadataKey)?.value
+  return metadataItemValue
+    ? deserializeMetadata(metadataItemValue).envId
+    : extractDefined(labels ?? {}, LABELS.OLD_ENV_ID) // backwards compat
+}
+
 const machineFromInstance = (
   instance: Instance,
 ): SshMachine & { envId: string } => {
@@ -43,7 +52,7 @@ const machineFromInstance = (
     sshUsername: SSH_USERNAME,
     providerId: instance.name as string,
     version: '',
-    envId: deserializeMetadata(instance.metadata?.items?.find(({ key }) => key === metadataKey)?.value as string).envId,
+    envId: envIdFromInstance(instance),
   }
 }
 

--- a/packages/driver-gce/src/driver/index.ts
+++ b/packages/driver-gce/src/driver/index.ts
@@ -15,7 +15,7 @@ import {
 } from '@preevy/core'
 import { pick } from 'lodash'
 import createClient, { Client, Instance, availableRegions, defaultProjectId, shortResourceName } from './client'
-import { LABELS } from './labels'
+import { deserializeMetadata, metadataKey } from './metadata'
 
 type DriverContext = {
   log: Logger
@@ -43,7 +43,7 @@ const machineFromInstance = (
     sshUsername: SSH_USERNAME,
     providerId: instance.name as string,
     version: '',
-    envId: instance.labels?.[LABELS.ENV_ID] as string,
+    envId: deserializeMetadata(instance.metadata?.items?.find(({ key }) => key === metadataKey)?.value as string).envId,
   }
 }
 

--- a/packages/driver-gce/src/driver/labels.ts
+++ b/packages/driver-gce/src/driver/labels.ts
@@ -1,8 +1,13 @@
-import { createHash } from 'crypto'
+import { truncateWithHash } from '@preevy/core'
 
 export const LABELS = {
-  ENV_ID_HASH_SHA1_HEX: 'preevy-env-id-hash-sha1-hex',
-  PROFILE_ID_HASH_SHA1_HEX: 'preevy-profile-id-hash-sha1-hex',
+  OLD_PROFILE_ID: 'preevy-profile-id',
+  OLD_ENV_ID: 'preevy-env-id',
+  ENV_ID: 'preevy-env-id-normalized',
+  PROFILE_ID: 'preevy-profile-id-normalized',
 }
 
-export const sha1hex = (s: string) => createHash('sha1').update(s).digest('hex')
+// https://cloud.google.com/compute/docs/labeling-resources#requirements
+export const isValidLabel = (label: string) => label.length <= 63 && /[a-z0-9_-]/.test(label)
+
+export const normalizeLabel = (s: string) => truncateWithHash(s, 63).toLowerCase()

--- a/packages/driver-gce/src/driver/labels.ts
+++ b/packages/driver-gce/src/driver/labels.ts
@@ -1,4 +1,8 @@
+import { createHash } from 'crypto'
+
 export const LABELS = {
-  PROFILE_ID: 'preevy-profile-id',
-  ENV_ID: 'preevy-env-id',
+  ENV_ID_HASH_SHA1_HEX: 'preevy-env-id-hash-sha1-hex',
+  PROFILE_ID_HASH_SHA1_HEX: 'preevy-profile-id-hash-sha1-hex',
 }
+
+export const sha1hex = (s: string) => createHash('sha1').update(s).digest('hex')

--- a/packages/driver-gce/src/driver/metadata.ts
+++ b/packages/driver-gce/src/driver/metadata.ts
@@ -1,0 +1,9 @@
+type InstanceMetadata = {
+  envId: string
+  profileId: string
+}
+
+export const metadataKey = 'preevy-env'
+
+export const serializeMetadata = (metadata: InstanceMetadata) => JSON.stringify(metadata)
+export const deserializeMetadata = (metadata: string) => JSON.parse(metadata) as InstanceMetadata


### PR DESCRIPTION
label contained the envId as is, which does not adhere to the [allowed characters](https://cloud.google.com/compute/docs/labeling-resources#requirements).

fixed by storing a hash of the envId and profileId, in the labels, which are used as a filter when querying the instances. actual values are stored in the [instance metadata](https://cloud.google.com/compute/docs/metadata/setting-custom-metadata) and returned for the ls command.

fixes #153
