### PR TITLE
add profile cp command

### DIFF
--- a/packages/cli-common/src/lib/text.ts
+++ b/packages/cli-common/src/lib/text.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 
 export const code = (c: string) => chalk.bold(c)
 
-export const codeList = (c: string[]) => c.map(code).join(', ')
+export const codeList = (c: string[] | readonly string[]) => c.map(code).join(', ')
 
 export const command = ({ bin }: Pick<Config, 'bin'>, ...args: string[]) => code(`${bin} ${args.join(' ')}`)
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,14 +1,12 @@
 import { Flags, Args, ux } from '@oclif/core'
 import inquirer from 'inquirer'
 import confirm from '@inquirer/confirm'
-import { defaultBucketName as gsDefaultBucketName, defaultProjectId as defaultGceProjectId } from '@preevy/driver-gce'
-import { defaultBucketName as s3DefaultBucketName, AWS_REGIONS, awsUtils } from '@preevy/driver-lightsail'
 import { BaseCommand, text } from '@preevy/cli-common'
 import { EOL } from 'os'
 import { Flag } from '@oclif/core/lib/interfaces'
 import { DriverName, formatDriverFlagsToArgs, machineDrivers } from '../drivers'
 import { loadProfileConfig } from '../profile-command'
-import ambientAwsAccountId = awsUtils.ambientAccountId
+import { chooseFs, chooseFsType } from '../fs'
 
 const chooseDriver = async () => (
   await inquirer.prompt<{ driver: DriverName }>([
@@ -25,89 +23,6 @@ const chooseDriver = async () => (
     },
   ])
 ).driver
-
-const locationTypes = ['local', 's3', 'gs'] as const
-type LocationType = typeof locationTypes[number]
-
-const chooseLocationType = async () => (
-  await inquirer.prompt<{ locationType: LocationType }>([
-    {
-      type: 'list',
-      name: 'locationType',
-      message: 'Where do you want to store the profile?',
-      default: 'local',
-      choices: [
-        { value: 'local', name: 'local file' },
-        { value: 's3', name: 'AWS S3' },
-        { value: 'gs', name: 'Google Cloud Storage' },
-      ],
-    },
-  ])
-).locationType
-
-type LocationFactory = (opts: {
-  profileAlias: string
-  driver: DriverName
-  driverFlags: Record<string, unknown>
-}) => Promise<`${string}://${string}`>
-
-const chooseLocation: Record<LocationType, LocationFactory> = {
-  local: async ({ profileAlias }: { profileAlias: string }) => `local://${profileAlias}`,
-  s3: async ({ profileAlias, driver, driverFlags }: {
-    profileAlias: string
-    driver: DriverName
-    driverFlags: Record<string, unknown>
-  }) => {
-    // eslint-disable-next-line no-use-before-define
-    const { region, bucket } = await inquirer.prompt<{ region: string; bucket: string }>([
-      {
-        type: 'list',
-        name: 'region',
-        message: 'S3 bucket region',
-        choices: AWS_REGIONS,
-        default: driver === 'lightsail' ? driverFlags.region as string : 'us-east-1',
-      },
-      {
-        type: 'input',
-        name: 'bucket',
-        message: 'Bucket name',
-        default: async (
-          answers: Record<string, unknown>
-        ) => {
-          const accountId = await ambientAwsAccountId(answers.region as string)
-          return accountId ? s3DefaultBucketName({ profileAlias, accountId }) : undefined
-        },
-      },
-    ])
-
-    return `s3://${bucket}?region=${region}`
-  },
-  gs: async ({ profileAlias, driver, driverFlags }: {
-    profileAlias: string
-    driver: DriverName
-    driverFlags: Record<string, unknown>
-  }) => {
-    // eslint-disable-next-line no-use-before-define
-    const { project, bucket } = await inquirer.prompt<{ project: string; bucket: string }>([
-      {
-        type: 'input',
-        name: 'project',
-        message: 'Google Cloud project',
-        default: driver === 'gce' ? driverFlags['project-id'] : defaultGceProjectId(),
-      },
-      {
-        type: 'input',
-        name: 'bucket',
-        message: 'Bucket name',
-        default: (
-          answers: Record<string, unknown>,
-        ) => gsDefaultBucketName({ profileAlias, project: answers.project as string }),
-      },
-    ])
-
-    return `gs://${bucket}?project=${project}`
-  },
-}
 
 export default class Init extends BaseCommand {
   static description = 'Initialize or import a new profile'
@@ -150,9 +65,9 @@ export default class Init extends BaseCommand {
     const driverAnswers = await inquirer.prompt<Record<string, unknown>>(await driverStatic.questions())
     const driverFlags = await driverStatic.flagsFromAnswers(driverAnswers) as Record<string, unknown>
 
-    const locationType = await chooseLocationType()
+    const locationType = await chooseFsType()
 
-    const location = await chooseLocation[locationType]({ profileAlias, driver, driverFlags })
+    const location = await chooseFs[locationType]({ profileAlias, driver: { name: driver, flags: driverFlags } })
 
     await this.config.runCommand('profile:create', [
       '--use',

--- a/packages/cli/src/commands/profile/cp.ts
+++ b/packages/cli/src/commands/profile/cp.ts
@@ -1,0 +1,135 @@
+import { FlagOutput, ArgOutput, ParserOutput } from '@oclif/core/lib/interfaces/parser'
+import { Args, Flags, ux } from '@oclif/core'
+import inquirer from 'inquirer'
+import { BaseCommand, text } from '@preevy/cli-common'
+import { LocalProfilesConfig } from '@preevy/core'
+import { mapValues } from 'lodash'
+import { loadProfileConfig } from '../../profile-command'
+import { chooseFs, chooseFsType } from '../../fs'
+import { machineDrivers } from '../../drivers'
+
+const parseFsType = (target: string) => {
+  const [fsType, ...rest] = target.split('://')
+  return rest.length ? fsType : undefined
+}
+
+// eslint-disable-next-line no-use-before-define
+export default class CopyProfile extends BaseCommand<typeof CopyProfile> {
+  static description = 'Copy a profile to another storage'
+
+  static args = {
+    source: Args.string({
+      description: 'Source profile name, defaults to the current profile',
+      required: false,
+    }),
+    target: Args.string({
+      description: 'Target profile. Either a URL or a name, in which case the command will require interactive input to build the URL',
+      required: true,
+    }),
+  }
+
+  static enableJsonFlag = true
+
+  static flags = {
+    use: Flags.boolean({
+      description: 'use the new profile',
+      required: false,
+    }),
+    targetName: Flags.string({
+      description: 'Target profile name',
+      required: false,
+    }),
+  }
+
+  // workaround for oclif bug when a required arg follows an optional arg
+  protected async parse<
+    F extends FlagOutput,
+    B extends FlagOutput,
+    A extends ArgOutput,
+  >(): Promise<ParserOutput<F, B, A>> {
+    const { args, ...result } = await super.parse({
+      flags: CopyProfile.flags,
+      baseFlags: CopyProfile.baseFlags,
+      args: mapValues(CopyProfile.args, v => ({ ...v, required: false })) as typeof CopyProfile.args,
+      strict: true,
+    })
+    if (!args.source) {
+      throw new Error('You must specify a target')
+    }
+    const bothSpecified = args.target !== undefined
+    return {
+      ...result,
+      args: {
+        source: bothSpecified ? args.source : undefined,
+        target: bothSpecified ? args.target : args.source,
+      },
+    } as unknown as ParserOutput<F, B, A>
+  }
+
+  public async init(): Promise<void> {
+    await super.init()
+    this.targetFsType = parseFsType(this.args.target)
+  }
+
+  async source(profileConfig: LocalProfilesConfig): Promise<{
+    alias: string
+    location: string
+  }> {
+    console.log('args', this.args)
+    if (this.args.source) {
+      const { location } = await profileConfig.get(this.args.source)
+      return { alias: this.args.source, location }
+    }
+    const result = await profileConfig.current()
+    if (!result) {
+      throw new Error('No current profile, specify the source alias')
+    }
+    return result
+  }
+
+  async targetAlias(source: { alias: string }, fsType: string): Promise<string> {
+    if (this.flags.targetName) {
+      return this.flags.targetName
+    }
+    // eslint-disable-next-line no-use-before-define
+    const { targetAlias } = await inquirer.prompt<{ targetAlias: string }>([
+      {
+        type: 'input',
+        name: 'targetAlias',
+        message: 'Target profile name',
+        default: `${source.alias}-${fsType}`,
+      },
+    ])
+    return targetAlias
+  }
+
+  targetFsType: string | undefined
+
+  async target(source: { alias: string }): Promise<{ url: string; alias: string }> {
+    if (this.targetFsType) {
+      return { url: this.args.target, alias: await this.targetAlias(source, this.targetFsType) }
+    }
+    const fsType = await chooseFsType()
+    const alias = await this.targetAlias(source, fsType)
+    return { url: await chooseFs[fsType]({ profileAlias: alias }), alias }
+  }
+
+  async run(): Promise<unknown> {
+    const profileConfig = loadProfileConfig(this.config)
+    const source = await this.source(profileConfig)
+    const target = await this.target(source)
+    await profileConfig.copy(
+      { location: source.location },
+      { alias: target.alias, location: target.url },
+      Object.keys(machineDrivers),
+    )
+
+    ux.info(text.success(`Profile ${text.code(source.alias)} copied to ${text.code(target.url)} as ${text.code(target.alias)}`))
+
+    if (this.flags.use) {
+      await profileConfig.setCurrent(target.alias)
+    }
+
+    return { source, target }
+  }
+}

--- a/packages/cli/src/commands/profile/create.ts
+++ b/packages/cli/src/commands/profile/create.ts
@@ -19,18 +19,18 @@ export default class CreateProfile extends ProfileCommand<typeof CreateProfile> 
     ...machineCreationflagsForAllDrivers,
     driver: DriverCommand.baseFlags.driver,
     use: Flags.boolean({
-      description: 'use the new profile',
+      description: 'Mark the new profile as the current profile',
       required: false,
     }),
   }
 
   static args = {
     name: Args.string({
-      description: 'name of the new profile',
+      description: 'Name of the new profile',
       required: true,
     }),
     url: Args.string({
-      description: 'url of the new profile store',
+      description: 'URL of the new profile',
       required: true,
     }),
   }

--- a/packages/cli/src/commands/profile/import.ts
+++ b/packages/cli/src/commands/profile/import.ts
@@ -20,18 +20,18 @@ export default class ImportProfile extends BaseCommand<typeof ImportProfile> {
 
   static flags = {
     name: Flags.string({
-      description: 'name of the profile',
+      description: 'Name of the profile',
       required: false,
     }),
     use: Flags.boolean({
-      description: 'use the imported profile',
+      description: 'Mark the new profile as the current profile',
       required: false,
     }),
   }
 
   static args = {
     location: Args.string({
-      description: 'location of the profile',
+      description: 'URL of the profile',
       required: true,
     }),
   }

--- a/packages/cli/src/commands/profile/ls.ts
+++ b/packages/cli/src/commands/profile/ls.ts
@@ -5,8 +5,6 @@ import ProfileCommand from '../../profile-command'
 export default class ListProfile extends ProfileCommand<typeof ListProfile> {
   static description = 'Lists profiles'
 
-  static strict = false
-
   static enableJsonFlag = true
 
   async run(): Promise<unknown> {
@@ -14,8 +12,12 @@ export default class ListProfile extends ProfileCommand<typeof ListProfile> {
     const profiles = await this.profileConfig.list()
 
     if (this.flags.json) {
-      return profiles
+      return {
+        profiles: Object.fromEntries(profiles.map(({ alias, ...rest }) => [alias, rest])),
+        current: currentProfile?.alias,
+      }
     }
+
     ux.table(profiles, {
       alias: {
         header: 'Alias',

--- a/packages/cli/src/commands/profile/use.ts
+++ b/packages/cli/src/commands/profile/use.ts
@@ -1,8 +1,9 @@
 import { Args, ux } from '@oclif/core'
-import ProfileCommand from '../../profile-command'
+import { BaseCommand } from '@preevy/cli-common'
+import { loadProfileConfig } from '../../profile-command'
 
 // eslint-disable-next-line no-use-before-define
-export default class UseProfile extends ProfileCommand<typeof UseProfile> {
+export default class UseProfile extends BaseCommand<typeof UseProfile> {
   static description = 'Set current profile'
 
   static args = {
@@ -12,13 +13,10 @@ export default class UseProfile extends ProfileCommand<typeof UseProfile> {
     }),
   }
 
-  static strict = false
-
-  static enableJsonFlag = true
-
   async run(): Promise<unknown> {
     const alias = this.args.name
-    await this.profileConfig.setCurrent(alias)
+    const profileConfig = loadProfileConfig(this.config)
+    await profileConfig.setCurrent(alias)
     ux.info(`Profile ${alias} is now being used`)
     return undefined
   }

--- a/packages/cli/src/commands/profile/use.ts
+++ b/packages/cli/src/commands/profile/use.ts
@@ -1,5 +1,5 @@
 import { Args, ux } from '@oclif/core'
-import { BaseCommand } from '@preevy/cli-common'
+import { BaseCommand, text } from '@preevy/cli-common'
 import { loadProfileConfig } from '../../profile-command'
 
 // eslint-disable-next-line no-use-before-define
@@ -17,7 +17,7 @@ export default class UseProfile extends BaseCommand<typeof UseProfile> {
     const alias = this.args.name
     const profileConfig = loadProfileConfig(this.config)
     await profileConfig.setCurrent(alias)
-    ux.info(`Profile ${alias} is now being used`)
+    ux.info(text.success(`Profile ${text.code(alias)} is now being used`))
     return undefined
   }
 }

--- a/packages/cli/src/fs.ts
+++ b/packages/cli/src/fs.ts
@@ -25,6 +25,7 @@ export const fsFromUrl = async (url: string, localBaseDir: string) => {
 
 export const fsTypes = ['local', 's3', 'gs'] as const
 export type FsType = typeof fsTypes[number]
+export const isFsType = (s: string): s is FsType => fsTypes.includes(s as FsType)
 
 export const chooseFsType = async () => (
   await inquirer.prompt<{ locationType: FsType }>([

--- a/packages/cli/src/fs.ts
+++ b/packages/cli/src/fs.ts
@@ -1,6 +1,9 @@
 import { fsTypeFromUrl, localFsFromUrl } from '@preevy/core'
-import { googleCloudStorageFs } from '@preevy/driver-gce'
-import { s3fs } from '@preevy/driver-lightsail'
+import { googleCloudStorageFs, defaultBucketName as gsDefaultBucketName, defaultProjectId as defaultGceProjectId } from '@preevy/driver-gce'
+import { s3fs, defaultBucketName as s3DefaultBucketName, AWS_REGIONS, awsUtils } from '@preevy/driver-lightsail'
+import inquirer from 'inquirer'
+import { DriverName } from './drivers'
+import ambientAwsAccountId = awsUtils.ambientAccountId
 
 export const fsFromUrl = async (url: string, localBaseDir: string) => {
   const fsType = fsTypeFromUrl(url)
@@ -18,4 +21,84 @@ export const fsFromUrl = async (url: string, localBaseDir: string) => {
     return await googleCloudStorageFs(url)
   }
   throw new Error(`Unsupported URL type: ${fsType}`)
+}
+
+export const fsTypes = ['local', 's3', 'gs'] as const
+export type FsType = typeof fsTypes[number]
+
+export const chooseFsType = async () => (
+  await inquirer.prompt<{ locationType: FsType }>([
+    {
+      type: 'list',
+      name: 'locationType',
+      message: 'Where do you want to store the profile?',
+      default: 'local',
+      choices: [
+        { value: 'local', name: 'local file' },
+        { value: 's3', name: 'AWS S3' },
+        { value: 'gs', name: 'Google Cloud Storage' },
+      ],
+    },
+  ])
+).locationType
+
+export type FsChooser = (opts: {
+  profileAlias: string
+  driver?: { name: DriverName; flags: Record<string, unknown> }
+}) => Promise<`${string}://${string}`>
+
+export const chooseFs: Record<FsType, FsChooser> = {
+  local: async ({ profileAlias }: { profileAlias: string }) => `local://${profileAlias}`,
+  s3: async ({ profileAlias, driver }: {
+    profileAlias: string
+    driver?: { name: DriverName; flags: Record<string, unknown> }
+  }) => {
+    // eslint-disable-next-line no-use-before-define
+    const { region, bucket } = await inquirer.prompt<{ region: string; bucket: string }>([
+      {
+        type: 'list',
+        name: 'region',
+        message: 'S3 bucket region',
+        choices: AWS_REGIONS,
+        default: driver?.name === 'lightsail' ? driver.flags.region as string : 'us-east-1',
+      },
+      {
+        type: 'input',
+        name: 'bucket',
+        message: 'Bucket name',
+        default: async (
+          answers: Record<string, unknown>
+        ) => {
+          const accountId = await ambientAwsAccountId(answers.region as string)
+          return accountId ? s3DefaultBucketName({ profileAlias, accountId }) : undefined
+        },
+      },
+    ])
+
+    return `s3://${bucket}?region=${region}`
+  },
+  gs: async ({ profileAlias, driver }: {
+    profileAlias: string
+    driver?: { name: DriverName; flags: Record<string, unknown> }
+  }) => {
+    // eslint-disable-next-line no-use-before-define
+    const { project, bucket } = await inquirer.prompt<{ project: string; bucket: string }>([
+      {
+        type: 'input',
+        name: 'project',
+        message: 'Google Cloud project',
+        default: driver?.name === 'gce' ? driver.flags['project-id'] : defaultGceProjectId(),
+      },
+      {
+        type: 'input',
+        name: 'bucket',
+        message: 'Bucket name',
+        default: (
+          answers: Record<string, unknown>,
+        ) => gsDefaultBucketName({ profileAlias, project: answers.project as string }),
+      },
+    ])
+
+    return `gs://${bucket}?project=${project}`
+  },
 }

--- a/packages/cli/src/profile-command.ts
+++ b/packages/cli/src/profile-command.ts
@@ -56,14 +56,14 @@ abstract class ProfileCommand<T extends typeof Command> extends BaseCommand<T> {
     if (!profileAlias) {
       return
     }
-    const currentProfileInfo = await profileConfig.get(profileAlias)
-    if (!currentProfileInfo) {
+    const currentProfileConfig = await profileConfig.get(profileAlias)
+    if (!currentProfileConfig) {
       return
     }
 
-    this.#profile = currentProfileInfo.info
-    this.#store = currentProfileInfo.store
-    onProfileChange(currentProfileInfo.info, profileAlias, currentProfileInfo.location)
+    this.#profile = currentProfileConfig.info
+    this.#store = currentProfileConfig.store
+    onProfileChange(currentProfileConfig.info, profileAlias, currentProfileConfig.location)
   }
 
   #profileConfig: LocalProfilesConfig | undefined

--- a/packages/core/src/profile/store.ts
+++ b/packages/core/src/profile/store.ts
@@ -19,9 +19,6 @@ export const profileStore = (store: Store) => {
     info: async () => await ref.readJsonOrThrow<Profile>('info.json'),
     defaultFlags: async<T>(driver: string) => {
       const profile = await ref.readJSON<T>(`${driver}-defaults.json`)
-      if (!profile) {
-        return {}
-      }
       return profile ?? {}
     },
     async updateDriver(driver: string) {


### PR DESCRIPTION
fixes #231 

```
➜  preevy git:(cli-profile-cp) ~/preevy/packages/cli/bin/dev profile cp --help
Copy a profile

USAGE
  $ preevy profile cp [-D] [-f <value>] [--system-compose-file <value>] [-p <value>] [--json]
    [--profile <value>] [--target-location <value> | --target-storage local|s3|gs] [--target-name
    <value>] [--use]

FLAGS
  --profile=<value>          Source profile name, defaults to the current profile
  --target-location=<value>  Target profile location URL
  --target-name=<value>      Target profile name
  --target-storage=<option>  Target profile storage type
                             <options: local|s3|gs>
  --use                      Mark the new profile as the current profile

GLOBAL FLAGS
  -D, --debug                       Enable debug logging
  -f, --file=<value>...             [default: ] Compose configuration file
  -p, --project=<value>             Project name. Defaults to the Compose project name
  --json                            Format output as json.
  --system-compose-file=<value>...  [default: ] Add extra Compose configuration file without overriding
                                    the defaults

DESCRIPTION
  Copy a profile
```