### PR TITLE
Update ssh connection metric to use clientId for aggression

### DIFF
--- a/tunnel-server/src/metrics.ts
+++ b/tunnel-server/src/metrics.ts
@@ -4,7 +4,7 @@ import { Gauge, Counter, register } from 'prom-client'
 export const sshConnectionsGauge = new Gauge({
   name: 'sshConnections',
   help: 'Current number of open SSH connections',
-  labelNames: ['envId'],
+  labelNames: ['clientId'],
 })
 
 export const tunnelsGauge = new Gauge({

--- a/tunnel-server/src/ssh/index.ts
+++ b/tunnel-server/src/ssh/index.ts
@@ -28,8 +28,8 @@ export const createSshServer = ({
 }) => {
   const onClient = (client: BaseSshClient) => {
     const { clientId, publicKey, envId, connectionId, publicKeyThumbprint, log } = client
-    sshConnectionsGauge.inc({ envId })
-    const cleanupClient = once(() => { sshConnectionsGauge.dec({ envId }) })
+    sshConnectionsGauge.inc({ clientId })
+    const cleanupClient = once(() => { sshConnectionsGauge.dec({ clientId }) })
     const tunnels = new Map<string, string>()
     client
       .on('forward', async (requestId, { path: tunnelPath, access, meta, inject }, localSocketPath, accept, reject) => {


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to Preevy! 🎉 -->

<!-- Please fill in the below placeholders -->

**[Is this a bugfix/feature/doc-improvement?]**

## This is a

- [ ] Bug fix
- [ ] Feature
- [ ] Doc improvement

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

- [ ] I have used Preevy for a while and am familiar with the function it provides.

If this is a bug fix or feature:

- [ ] I tested the proposed change on my cloud provider: **Please specify which provider**
- [ ] I tested the proposed change on a local Kubernetes cluster.
