### PR TITLE
kube driver: move to StatefulSet

### DIFF
--- a/packages/cli/.eslintignore
+++ b/packages/cli/.eslintignore
@@ -1,3 +1,4 @@
 /dist
 node_modules
 /scripts
+/tmp

--- a/packages/cli/src/commands/down.ts
+++ b/packages/cli/src/commands/down.ts
@@ -1,10 +1,10 @@
 import { Flags } from '@oclif/core'
 import { findEnvId, machineResourceType, withSpinner } from '@preevy/core'
-import DriverCommand from '../driver-command.js'
+import MachineCreationDriverCommand from '../machine-creation-driver-command.js'
 import { envIdFlags } from '../common-flags.js'
 
 // eslint-disable-next-line no-use-before-define
-export default class Down extends DriverCommand<typeof Down> {
+export default class Down extends MachineCreationDriverCommand<typeof Down> {
   static description = 'Delete preview environments'
 
   static flags = {
@@ -28,6 +28,7 @@ export default class Down extends DriverCommand<typeof Down> {
     const log = this.logger
     const { flags } = this
     const driver = await this.driver()
+    const machineCreationDriver = await this.machineCreationDriver()
 
     const envId = await findEnvId({
       log,
@@ -45,7 +46,10 @@ export default class Down extends DriverCommand<typeof Down> {
     }
 
     await withSpinner(async () => {
-      await driver.deleteResources(flags.wait, { type: machineResourceType, providerId: machine.providerId })
+      await machineCreationDriver.deleteResources(
+        flags.wait,
+        { type: machineResourceType, providerId: machine.providerId },
+      )
     }, { opPrefix: `Deleting ${driver.friendlyName} machine ${machine.providerId} for environment ${envId}` })
 
     await Promise.all(

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -55,7 +55,7 @@ export default class Init extends BaseCommand {
 
     const driver = await chooseDriver()
     const driverStatic = machineDrivers[driver]
-    const driverFlags = await driverStatic.inquireFlags()
+    const driverFlags = await driverStatic.inquireFlags({ log: this.logger })
 
     ux.info(text.recommendation('To use Preevy in a CI flow, select a remote storage for your profile.'))
     const locationType = await chooseFsType(({ driver }))

--- a/packages/cli/src/commands/purge.ts
+++ b/packages/cli/src/commands/purge.ts
@@ -3,7 +3,7 @@ import { Flags, ux } from '@oclif/core'
 import { asyncFilter, asyncToArray } from 'iter-tools-es'
 import { groupBy, partition } from 'lodash-es'
 import { MachineResource, isPartialMachine, machineResourceType } from '@preevy/core'
-import DriverCommand from '../driver-command.js'
+import MachineCreationDriverCommand from '../machine-creation-driver-command.js'
 import { carefulBooleanPrompt } from '../prompt.js'
 
 const isMachineResource = (r: { type: string }): r is MachineResource => r.type === machineResourceType
@@ -35,7 +35,7 @@ const confirmPurge = async (
 }
 
 // eslint-disable-next-line no-use-before-define
-export default class Purge extends DriverCommand<typeof Purge> {
+export default class Purge extends MachineCreationDriverCommand<typeof Purge> {
   static description = 'Delete all cloud provider machines and potentially other resources'
 
   static flags = {
@@ -68,6 +68,7 @@ export default class Purge extends DriverCommand<typeof Purge> {
     const { flags } = this
 
     const driver = await this.driver()
+    const creationDriver = await this.machineCreationDriver()
     const resourcePlurals: Record<string, string> = { [machineResourceType]: 'machines', ...driver.resourcePlurals }
     const driverResourceTypes = new Set(Object.keys(resourcePlurals))
 
@@ -83,7 +84,7 @@ export default class Purge extends DriverCommand<typeof Purge> {
     const allResources = await asyncToArray(
       asyncFilter(
         ({ type }) => flags.all || flags.type.includes(type),
-        driver.listDeletableResources(),
+        creationDriver.listDeletableResources(),
       ),
     )
 
@@ -106,7 +107,7 @@ export default class Purge extends DriverCommand<typeof Purge> {
       return undefined
     }
 
-    await driver.deleteResources(flags.wait, ...allResources)
+    await creationDriver.deleteResources(flags.wait, ...allResources)
 
     if (flags.json) {
       return allResources

--- a/packages/cli/src/hooks/init/load-plugins.ts
+++ b/packages/cli/src/hooks/init/load-plugins.ts
@@ -7,7 +7,7 @@ const wrappedHook: OclifHook<'init'> = async function wrappedHook(...args) {
     await initHook.call(this, ...args)
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.warn(`warning: failed to init context: ${e}`)
+    console.warn(`warning: failed to init context: ${(e as Error).stack || e}`)
     telemetryEmitter().capture('plugin-init-error', { error: e })
     await telemetryEmitter().flush()
     process.exit(1)

--- a/packages/core/src/driver/driver.ts
+++ b/packages/core/src/driver/driver.ts
@@ -17,7 +17,6 @@ export type MachineConnection = Disposable & {
 
 export type MachineDriver<
   Machine extends MachineBase = MachineBase,
-  ResourceType extends string = string
 > = {
   customizationScripts?: string[]
   friendlyName: string
@@ -33,8 +32,6 @@ export type MachineDriver<
   ) => Promise<{ code: number } | { signal: string }>
 
   listMachines: () => AsyncIterableIterator<Machine | PartialMachine>
-  listDeletableResources: () => AsyncIterableIterator<Resource<ResourceType>>
-  deleteResources: (wait: boolean, ...resource: Resource<string>[]) => Promise<void>
   machineStatusCommand: (machine: MachineBase) => Promise<MachineStatusCommand | undefined>
 }
 
@@ -43,7 +40,10 @@ export type MachineCreationResult<Machine extends MachineBase = MachineBase> = {
   result: Promise<{ machine: Machine; connection: MachineConnection }>
 }
 
-export type MachineCreationDriver<Machine extends MachineBase = MachineBase> = {
+export type MachineCreationDriver<
+  Machine extends MachineBase = MachineBase,
+  ResourceType extends string = string,
+> = {
   metadata: Record<string, unknown>
 
   createMachine: (args: {
@@ -54,24 +54,30 @@ export type MachineCreationDriver<Machine extends MachineBase = MachineBase> = {
   getMachineAndSpecDiff: (
     args: { envId: string },
   ) => Promise<(Machine & { specDiff: SpecDiffItem[] }) | PartialMachine | undefined>
+
+  listDeletableResources: () => AsyncIterableIterator<Resource<ResourceType>>
+  deleteResources: (wait: boolean, ...resource: Resource<string>[]) => Promise<void>
 }
 
 export type MachineDriverFactory<
   Flags,
   Machine extends MachineBase = MachineBase,
-  ResourceType extends string = string
 > = ({ flags, profile, store, log, debug }: {
   flags: Flags
   profile: Profile
   store: Store
   log: Logger
   debug: boolean
-}) => MachineDriver<Machine, ResourceType>
+}) => MachineDriver<Machine>
 
-export type MachineCreationDriverFactory<Flags, Machine extends MachineBase> = ({ flags, profile, store, log, debug }: {
+export type MachineCreationDriverFactory<
+  Flags,
+  Machine extends MachineBase,
+  ResourceType extends string = string,
+> = ({ flags, profile, store, log, debug }: {
   flags: Flags
   profile: Profile
   store: Store
   log: Logger
   debug: boolean
-}) => MachineCreationDriver<Machine>
+}) => MachineCreationDriver<Machine, ResourceType>

--- a/packages/core/src/driver/machine-operations.ts
+++ b/packages/core/src/driver/machine-operations.ts
@@ -53,7 +53,10 @@ const ensureBareMachine = async ({
   return await withSpinner(async spinner => {
     if (existingMachine && recreating) {
       spinner.text = 'Deleting machine'
-      await machineDriver.deleteResources(false, { type: machineResourceType, providerId: existingMachine.providerId })
+      await machineCreationDriver.deleteResources(
+        false,
+        { type: machineResourceType, providerId: existingMachine.providerId },
+      )
     }
     spinner.text = 'Checking for existing snapshot'
     const machineCreation = await machineCreationDriver.createMachine({ envId })

--- a/packages/driver-kube-pod/src/driver/client/common.ts
+++ b/packages/driver-kube-pod/src/driver/client/common.ts
@@ -13,4 +13,5 @@ export const bodyOrUndefined = async <T, Response extends { body: T } = { body: 
 }
 
 export type HasMetadata = { metadata?: k8s.V1ObjectMeta }
+export type HasKind = { kind?: string }
 export type Package = { version: string; name: string }

--- a/packages/driver-kube-pod/src/driver/client/dynamic/wait.ts
+++ b/packages/driver-kube-pod/src/driver/client/dynamic/wait.ts
@@ -10,11 +10,11 @@ const waiter = ({ watcher, client }: { watcher: k8s.Watch; client: k8s.Kubernete
     eventPredicate: (phase: string, apiObj: T) => boolean = () => true,
   ) => {
     const path = new URL(await urlGetter(o)).pathname
-    const { name, namespace } = ensureDefined(extractDefined(o, 'metadata'), 'name', 'namespace')
+    const { name, namespace } = ensureDefined(extractDefined(o, 'metadata'), 'name') // namespace can be undefined
     let abort: () => void
     return await new Promise<T>(resolve => {
       void watcher.watch(path, {}, (phase, apiObj: T) => {
-        const metadata = ensureDefined(extractDefined(apiObj, 'metadata'), 'name')
+        const metadata = ensureDefined(extractDefined(apiObj, 'metadata'), 'name') // namespace can be undefined
         if (
           metadata.name === name
           && metadata.namespace === namespace

--- a/packages/driver-kube-pod/src/driver/client/index.ts
+++ b/packages/driver-kube-pod/src/driver/client/index.ts
@@ -9,9 +9,13 @@ import { maxBy } from 'lodash-es'
 import { inspect } from 'util'
 import { Logger } from '@preevy/core'
 import baseExec from './exec/index.js'
-import dynamicApi, { ApplyFilter, applyStrategies, compositeApplyFilter } from './dynamic/index.js'
+import dynamicApi, { ApplyFilter, KubernetesType, applyStrategies, compositeApplyFilter } from './dynamic/index.js'
 import basePortForward from './port-forward.js'
-import k8sHelpers from './k8s-helpers.js'
+import {
+  podHelpers as createPodHelpers,
+  appsV1ApiHelpers as createAppsV1ApiHelpers,
+  coreV1ApiHelpers as createCoreV1ApiHelpers,
+} from './k8s-helpers.js'
 import {
   LABELS,
   addEnvMetadata,
@@ -23,15 +27,16 @@ import {
   extractTemplateHash,
   extractCreatedAt,
   extractName,
-  isDockerHostDeployment,
-  ANNOTATIONS,
+  isDockerHostStatefulSet,
+  addAllTypesAnnotation,
+  readAllTypesAnnotation,
 } from './metadata.js'
 import { Package } from './common.js'
 import { logError } from './log-error.js'
 
 const stringify = stringifyModule.default
 
-export const loadKubeConfig = (kubeconfig?: string, context?: string) => {
+export const loadKubeConfig = ({ kubeconfig, context }: { kubeconfig?: string; context?: string }) => {
   const kc = new k8s.KubeConfig()
   if (kubeconfig) {
     kc.loadFromFile(kubeconfig)
@@ -44,68 +49,202 @@ export const loadKubeConfig = (kubeconfig?: string, context?: string) => {
   return kc
 }
 
-export class DuplicateDockerHostDeployment extends Error {
+export class DuplicateDockerHostStatefulSet extends Error {
   constructor(readonly dups: [k8s.KubernetesObject, k8s.KubernetesObject]) {
-    super(`Duplicate Docker host Deployments found: ${inspect(dups)}`)
+    super(`Duplicate Docker host StatefulSets found: ${inspect(dups)}`)
   }
 }
 
-const ensureSingleDockerHostDeployment = (): ApplyFilter => {
-  let deployment: k8s.KubernetesObject
+const ensureSingleDockerHostStatefulSet = (
+  transform: (o: k8s.V1StatefulSet) => k8s.V1StatefulSet = o => o,
+): ApplyFilter => {
+  let statefulSet: k8s.KubernetesObject
   return s => {
-    if (isDockerHostDeployment(s)) {
-      if (deployment) {
-        throw new DuplicateDockerHostDeployment([deployment, s])
+    if (isDockerHostStatefulSet(s)) {
+      if (statefulSet) {
+        throw new DuplicateDockerHostStatefulSet([statefulSet, s])
       }
-      deployment = s
+      statefulSet = transform(s)
     }
     return s
   }
 }
 
-const kubeClient = ({ log, namespace, kc, profileId, template, package: packageDetails, kubeconfig }: {
+export const kubeClient = ({
+  log,
+  namespace,
+  kc,
+  profileId,
+  kubeconfig,
+}: {
   log: Logger
   kc: k8s.KubeConfig
   kubeconfig?: string
   namespace: string
   profileId: string
-  template: Buffer | string | Promise<Buffer | string>
-  package: Package | Promise<Package>
 }) => {
   const wrap = logError(log)
   const k8sApi = kc.makeApiClient(k8s.CoreV1Api)
   const k8sAppsApi = kc.makeApiClient(k8s.AppsV1Api)
+
+  const podHelpers = createPodHelpers({ k8sApi, k8sAppsApi, wrap })
+  const appsV1ApiHelpers = createAppsV1ApiHelpers(k8sAppsApi, { wrap })
+  const coreV1ApiHelpers = createCoreV1ApiHelpers(k8sApi, { wrap })
+
+  const listEnvStatefulSets = (
+    envId: string,
+    deleted?: boolean,
+  ) => appsV1ApiHelpers.listStatefulSets({
+    namespace,
+    ...envSelector({ profileId, envId, deleted, dockerHost: true }),
+  })
+
+  const listEnvDeployments = (
+    envId: string,
+    deleted?: boolean,
+  ) => appsV1ApiHelpers.listDeployments({
+    namespace,
+    ...envSelector({ profileId, envId, deleted, dockerHost: true }),
+  })
+
+  const findMostRecentDeployment = async ({ envId, deleted }: {
+    envId: string
+    deleted?: boolean
+  }): Promise<k8s.V1Deployment | undefined> => maxBy(
+    await asyncToArray(listEnvDeployments(envId, deleted)),
+    extractCreatedAt,
+  )
+
+  const findMostRecentStatefulSet = async ({ envId, deleted }: {
+    envId: string
+    deleted?: boolean
+  }): Promise<k8s.V1StatefulSet | undefined> => maxBy(
+    await asyncToArray(listEnvStatefulSets(envId, deleted)),
+    extractCreatedAt,
+  )
+
+  const findEnvObject = async (args: {
+    envId: string
+    deleted?: boolean
+  }): Promise<k8s.V1Deployment | k8s.V1StatefulSet | undefined> => await findMostRecentStatefulSet(args)
+    ?? await findMostRecentDeployment(args)
+
+  const portForward = async (
+    statefulSet: k8s.V1StatefulSet,
+    targetPort: number,
+    listenAddress: number | string | ListenOptions,
+  ) => {
+    const forward = new k8s.PortForward(kc)
+    const pod = await podHelpers.findReadyPodForStatefulSet(statefulSet)
+    const podName = extractName(pod)
+    return await basePortForward({ namespace, forward, log })(podName, targetPort, listenAddress)
+  }
+
+  const apiServiceClusterAddress = async (): Promise<[string, number] | undefined> => {
+    const service = await asyncFirst(coreV1ApiHelpers.listServices({
+      namespace: 'default',
+      fieldSelector: 'metadata.name=kubernetes',
+    }))
+    const [host, port] = [service?.spec?.clusterIP, service?.spec?.ports?.[0]?.port]
+    if (host === undefined || port === undefined) {
+      return undefined
+    }
+    return [host, port]
+  }
+
+  return {
+    findEnvObject,
+    findMostRecentDeployment,
+    findMostRecentStatefulSet,
+    listProfileStatefulSets: () => appsV1ApiHelpers.listStatefulSets({ namespace, ...profileSelector({ profileId }) }),
+    listProfileDeployments: () => appsV1ApiHelpers.listDeployments({ namespace, ...profileSelector({ profileId }) }),
+    exec: baseExec({ kubeConfig: kc, kubeconfigLocation: kubeconfig, namespace, log }),
+    findReadyPod: podHelpers.findReadyPod,
+    portForward,
+    apiServiceClusterAddress,
+  }
+}
+
+export type Client = ReturnType<typeof kubeClient>
+
+export const kubeCreationClient = ({
+  log,
+  namespace,
+  kc,
+  profileId,
+  template,
+  package: packageDetails,
+  storageClass,
+  storageSize,
+}: {
+  log: Logger
+  kc: k8s.KubeConfig
+  namespace: string
+  profileId: string
+  template: Buffer | string | Promise<Buffer | string>
+  package: Package | Promise<Package>
+  storageClass: string | undefined
+  storageSize: number
+}) => {
+  const wrap = logError(log)
+  const k8sAppsApi = kc.makeApiClient(k8s.AppsV1Api)
   const k8sObjApi = kc.makeApiClient(k8s.KubernetesObjectApi)
   const watcher = new k8s.Watch(kc)
 
-  const helpers = k8sHelpers({ k8sApi, k8sAppsApi, wrap })
+  const appsV1ApiHelpers = createAppsV1ApiHelpers(k8sAppsApi, { wrap })
 
-  const { apply, gatherTypes, list: dynamicList, waiter } = dynamicApi({ client: k8sObjApi, wrap })
+  const { apply, gatherTypes, uniqueTypes, list: dynamicList, waiter } = dynamicApi({ client: k8sObjApi, wrap })
 
   const renderTemplate = async ({ instance }: { instance: string }) => {
     const specsStr = nunjucks.renderString((await template).toString('utf-8'), {
       id: instance,
       namespace,
+      storageClass,
+      storageSize,
+      labels: {
+        [LABELS.PROFILE_ID]: profileId,
+        [LABELS.INSTANCE]: instance,
+      },
     })
     return yaml.parseAllDocuments(specsStr).map(d => d.toJS() as k8s.KubernetesObject)
   }
 
-  const calcTemplateHash = async ({ instance }: { instance: string }) => `sha1:${createHash('sha1').update(
-    stringify.stableStringify(await renderTemplate({ instance }))
+  const calcTemplateHash = async (
+    args: { instance: string } | { specs: k8s.KubernetesObject[] },
+  ) => `sha1:${createHash('sha1').update(
+    stringify.stableStringify('instance' in args ? await renderTemplate(args) : args.specs)
   ).digest('base64')}`
 
-  const listInstanceObjects = async (instance: string) => dynamicList(
-    gatherTypes(...await renderTemplate({ instance: '' })),
+  const findInstanceStatefulSet = async (instance: string) => {
+    const statefulSet = await asyncFirst(appsV1ApiHelpers.listStatefulSets({
+      namespace,
+      ...instanceSelector({ instance }),
+    }))
+
+    if (!statefulSet) {
+      throw new Error(`Cannot find StatefulSet with label "${LABELS.INSTANCE}": "${instance}" in namespace "${namespace}"`)
+    }
+    return statefulSet
+  }
+
+  const findInstanceAllTypesFromMetadata = async (instance: string): Promise<KubernetesType[]> => {
+    const statefulSet = await findInstanceStatefulSet(instance).catch(() => undefined)
+    const allTypes = statefulSet ? readAllTypesAnnotation(statefulSet) : undefined
+    return (allTypes ?? []).map(t => ({ ...t, namespace }))
+  }
+
+  const findInstanceAllTypes = async (instance: string): Promise<KubernetesType[]> => uniqueTypes([
+    ...await findInstanceAllTypesFromMetadata(instance),
+    ...gatherTypes(...await renderTemplate({ instance: '' })),
+    { kind: 'Deployment', apiVersion: 'apps/v1', namespace }, // backwards compatibility with Deployment-based envs
+  ])
+
+  const listInstanceObjects = async (
+    instance: string,
+  ) => dynamicList(
+    await findInstanceAllTypes(instance),
     { ...instanceSelector({ instance }) },
   )
-
-  const findInstanceDeployment = async (instance: string) => {
-    const deployment = await asyncFirst(helpers.listDeployments({ namespace, ...instanceSelector({ instance }) }))
-    if (!deployment) {
-      throw new Error(`Cannot find deployment with label "${LABELS.INSTANCE}": "${instance}" in namespace "${namespace}"`)
-    }
-    return deployment
-  }
 
   const createEnv = async (
     envId: string,
@@ -113,17 +252,25 @@ const kubeClient = ({ log, namespace, kc, profileId, template, package: packageD
   ) => {
     const instance = envRandomName({ envId, profileId })
     const specs = await renderTemplate({ instance })
+    const templateTypes = gatherTypes(...specs)
+      .map(({ kind, apiVersion, namespace: ns }) => ({ kind, apiVersion, namespaced: ns !== undefined }))
+
+    const allTypes = uniqueTypes([
+      { kind: 'PersistentVolumeClaim', apiVersion: 'v1', namespace }, // PVC associated with StatefulSet (they are not part of the template)
+      ...templateTypes,
+    ])
+
     log.debug('createEnv: apply', instance, inspect(specs, { depth: null }))
     await apply(specs, {
       filter: compositeApplyFilter(
-        ensureSingleDockerHostDeployment(),
+        ensureSingleDockerHostStatefulSet(s => addAllTypesAnnotation(s, allTypes)),
         addEnvMetadata({
           profileId,
           envId,
           createdAt: new Date(),
           instance,
           package: await packageDetails,
-          templateHash: await calcTemplateHash({ instance }),
+          templateHash: await calcTemplateHash({ specs }),
         })
       ),
       strategy: serverSideApply
@@ -131,17 +278,12 @@ const kubeClient = ({ log, namespace, kc, profileId, template, package: packageD
         : applyStrategies.clientSideApply,
     })
 
-    log.debug('createEnv: findInstanceDeployment', instance)
-    const deployment = await findInstanceDeployment(instance)
-
-    // objects returned by the list API missing 'kind' and 'apiVersion' props
-    // https://github.com/kubernetes/kubernetes/issues/3030
-    deployment.kind ??= deployment.metadata?.annotations?.[ANNOTATIONS.KUBERNETES_KIND] ?? 'Deployment'
-    deployment.apiVersion ??= deployment.metadata?.annotations?.[ANNOTATIONS.KUERBETES_API_VERSION] ?? 'apps/v1'
+    log.debug('createEnv: findInstanceStatefulSet', instance)
+    const statefulSet = await findInstanceStatefulSet(instance)
 
     return await waiter(watcher).waitForEvent(
-      deployment,
-      (_phase, d) => Boolean(d.status?.conditions?.some(({ type, status }) => type === 'Available' && status === 'True')),
+      statefulSet,
+      (_phase, ss) => ss.status?.readyReplicas === ss.spec?.replicas,
     )
   }
 
@@ -157,62 +299,15 @@ const kubeClient = ({ log, namespace, kc, profileId, template, package: packageD
     await apply(objects, { strategy: wait ? applyStrategies.deleteAndWait(watcher) : applyStrategies.delete })
   }
 
-  const listEnvDeployments = (
-    envId: string,
-    deleted?: boolean,
-  ) => helpers.listDeployments({
-    namespace,
-    ...envSelector({ profileId, envId, deleted, dockerHost: true }),
-  })
-
-  const findMostRecentDeployment = async ({ envId, deleted }: {
-    envId: string
-    deleted?: boolean
-  }): Promise<k8s.V1Deployment | undefined> => maxBy(
-    await asyncToArray(listEnvDeployments(envId, deleted)),
-    extractCreatedAt,
-  )
-
-  const portForward = async (
-    deployment: k8s.V1Deployment,
-    targetPort: number,
-    listenAddress: number | string | ListenOptions,
-  ) => {
-    const forward = new k8s.PortForward(kc)
-    const pod = await helpers.findReadyPodForDeployment(deployment)
-    const podName = extractName(pod)
-    return await basePortForward({ namespace, forward, log })(podName, targetPort, listenAddress)
-  }
-
-  const apiServiceClusterAddress = async (): Promise<[string, number] | undefined> => {
-    const service = await asyncFirst(helpers.listServices({
-      namespace: 'default',
-      fieldSelector: 'metadata.name=kubernetes',
-    }))
-    const [host, port] = [service?.spec?.clusterIP, service?.spec?.ports?.[0]?.port]
-    if (host === undefined || port === undefined) {
-      return undefined
-    }
-    return [host, port]
-  }
-
   return {
-    findMostRecentDeployment,
-    listProfileDeployments: () => helpers.listDeployments({ namespace, ...profileSelector({ profileId }) }),
-    exec: baseExec({ kubeConfig: kc, kubeconfigLocation: kubeconfig, namespace, log }),
-    findReadyPodForDeployment: helpers.findReadyPodForDeployment,
     createEnv,
     deleteEnv,
-    portForward,
     extractTemplateHash,
     calcTemplateHash,
-    apiServiceClusterAddress,
   }
 }
 
-export type Client = ReturnType<typeof kubeClient>
+export type CreationClient = ReturnType<typeof kubeCreationClient>
 
 export { extractInstance, extractEnvId, extractName, extractNamespace, extractTemplateHash } from './metadata.js'
 export { DeploymentNotReadyError, DeploymentNotReadyErrorReason } from './k8s-helpers.js'
-
-export default kubeClient

--- a/packages/driver-kube-pod/src/driver/client/k8s-helpers.ts
+++ b/packages/driver-kube-pod/src/driver/client/k8s-helpers.ts
@@ -1,8 +1,9 @@
 import * as k8s from '@kubernetes/client-node'
 import { ensureDefined, extractDefined } from '@preevy/core'
-import { asyncFilter, asyncFirst, asyncToArray } from 'iter-tools-es'
+import { asyncFilter, asyncFind, asyncFirst, asyncMap, asyncToArray } from 'iter-tools-es'
 import { paginationIterator } from './pagination.js'
 import { FuncWrapper } from './log-error.js'
+import { ANNOTATIONS, extractNameAndNamespace } from './metadata.js'
 
 export type DeploymentNotReadyErrorReason = 'NoRevision' | 'NoReplicaSet' | 'NoReadyPod'
 export class DeploymentNotReadyError extends Error {
@@ -11,63 +12,74 @@ export class DeploymentNotReadyError extends Error {
   }
 }
 
-export default (
-  { k8sAppsApi, k8sApi, wrap }: {
-    k8sAppsApi: k8s.AppsV1Api
-    k8sApi: k8s.CoreV1Api
-    wrap: FuncWrapper
+export class StatefulSetNotReadyError extends Error {
+  constructor(statefulSet: Pick<k8s.V1StatefulSet, 'metadata'>) {
+    super(`No ready pod found for StatefulSet "${statefulSet.metadata?.namespace}/${statefulSet.metadata?.name}"`)
   }
+}
+
+const readyPodPredicate = (p: k8s.V1Pod) => Boolean(p.status?.conditions?.some(c => c.type === 'Ready' && c.status === 'True'))
+
+// objects returned by the list API missing 'kind' and 'apiVersion' props
+// https://github.com/kubernetes/kubernetes/issues/3030
+const completeMissingListFields = <T extends k8s.KubernetesObject>(
+  { kind, apiVersion }: { kind: string; apiVersion: string },
+) => (o: T) => {
+    o.kind ??= o.metadata?.annotations?.[ANNOTATIONS.KUBERNETES_KIND] ?? kind
+    o.apiVersion ??= o.metadata?.annotations?.[ANNOTATIONS.KUERBETES_API_VERSION] ?? apiVersion
+    return o
+  }
+
+const completeMissingListFieldsAsyncIter = <T extends k8s.KubernetesObject>(
+  fields: { kind: string; apiVersion: string },
+  asyncIterator: AsyncIterable<T>,
+) => asyncMap(
+    completeMissingListFields(fields),
+    asyncIterator,
+  )
+
+export const storageV1ApiHelpers = (
+  storageApi: k8s.StorageV1Api,
+  { wrap = f => f }: { wrap?: FuncWrapper } = {}
 ) => {
-  const listDeployments = (
-    { namespace, fieldSelector, labelSelector, resourceVersion, timeoutSeconds, watch }: {
-      namespace: string
+  const listStorageClasses = (
+    { fieldSelector, labelSelector, resourceVersion, timeoutSeconds, watch }: {
       fieldSelector?: string
       labelSelector?: string
       resourceVersion?: string
       timeoutSeconds?: number
       watch?: boolean
     },
-  ) => paginationIterator<k8s.V1Deployment>(
-    wrap(continueToken => k8sAppsApi.listNamespacedDeployment(
-      namespace,
-      undefined,
-      undefined,
-      continueToken,
-      fieldSelector,
-      labelSelector,
-      undefined,
-      resourceVersion,
-      undefined,
-      timeoutSeconds,
-      watch,
-    )),
+  ) => completeMissingListFieldsAsyncIter(
+    { kind: 'StorageClass', apiVersion: 'storage.k8s.io/v1' },
+    paginationIterator<k8s.V1StorageClass>(
+      wrap(continueToken => storageApi.listStorageClass(
+        undefined,
+        undefined,
+        continueToken,
+        fieldSelector,
+        labelSelector,
+        undefined,
+        resourceVersion,
+        undefined,
+        timeoutSeconds,
+        watch,
+      )),
+    )
   )
 
-  const listReplicaSets = (
-    { namespace, fieldSelector, labelSelector, resourceVersion, timeoutSeconds, watch }: {
-      namespace: string
-      fieldSelector?: string
-      labelSelector?: string
-      resourceVersion?: string
-      timeoutSeconds?: number
-      watch?: boolean
-    },
-  ) => paginationIterator<k8s.V1ReplicaSet>(
-    wrap(continueToken => k8sAppsApi.listNamespacedReplicaSet(
-      namespace,
-      undefined,
-      undefined,
-      continueToken,
-      fieldSelector,
-      labelSelector,
-      undefined,
-      resourceVersion,
-      undefined,
-      timeoutSeconds,
-      watch,
-    )),
-  )
+  const findDefaultStorageClass = (storageClasses: k8s.V1StorageClass[]) => {
+    const defaultStorageClass = storageClasses.find(sc => sc?.metadata?.annotations?.['storageclass.kubernetes.io/is-default-class'] === 'true')
+    return defaultStorageClass
+  }
 
+  return { listStorageClasses, findDefaultStorageClass }
+}
+
+export const coreV1ApiHelpers = (
+  k8sApi: k8s.CoreV1Api,
+  { wrap = f => f }: { wrap?: FuncWrapper } = {}
+) => {
   const listPods = (
     { namespace, fieldSelector, labelSelector, resourceVersion, timeoutSeconds, watch }: {
       namespace: string
@@ -78,7 +90,7 @@ export default (
       timeoutSeconds?: number
       watch?: boolean
     },
-  ) => paginationIterator<k8s.V1Pod>(
+  ) => completeMissingListFieldsAsyncIter({ kind: 'Pod', apiVersion: 'v1' }, paginationIterator<k8s.V1Pod>(
     wrap(continueToken => k8sApi.listNamespacedPod(
       namespace,
       undefined,
@@ -92,7 +104,7 @@ export default (
       timeoutSeconds,
       watch,
     )),
-  )
+  ))
 
   const listServices = (
     { namespace, fieldSelector, labelSelector, resourceVersion, timeoutSeconds, watch }: {
@@ -103,7 +115,7 @@ export default (
       timeoutSeconds?: number
       watch?: boolean
     },
-  ) => paginationIterator<k8s.V1Service>(
+  ) => completeMissingListFieldsAsyncIter({ kind: 'Service', apiVersion: 'v1' }, paginationIterator<k8s.V1Service>(
     wrap(continueToken => k8sApi.listNamespacedService(
       namespace,
       undefined,
@@ -117,10 +129,135 @@ export default (
       timeoutSeconds,
       watch,
     )),
-  )
+  ))
+
+  return {
+    listPods,
+    listServices,
+  }
+}
+
+export const appsV1ApiHelpers = (
+  k8sAppsApi: k8s.AppsV1Api,
+  { wrap = f => f }: { wrap?: FuncWrapper } = {}
+) => {
+  const listStatefulSets = (
+    { namespace, fieldSelector, labelSelector, resourceVersion, timeoutSeconds, watch }: {
+      namespace: string
+      fieldSelector?: string
+      labelSelector?: string
+      resourceVersion?: string
+      timeoutSeconds?: number
+      watch?: boolean
+    },
+  ) => completeMissingListFieldsAsyncIter({ kind: 'StatefulSet', apiVersion: 'apps/v1' }, paginationIterator<k8s.V1StatefulSet>(
+    wrap(continueToken => k8sAppsApi.listNamespacedStatefulSet(
+      namespace,
+      undefined,
+      undefined,
+      continueToken,
+      fieldSelector,
+      labelSelector,
+      undefined,
+      resourceVersion,
+      undefined,
+      timeoutSeconds,
+      watch,
+    )),
+  ))
+
+  const listDeployments = (
+    { namespace, fieldSelector, labelSelector, resourceVersion, timeoutSeconds, watch }: {
+      namespace: string
+      fieldSelector?: string
+      labelSelector?: string
+      resourceVersion?: string
+      timeoutSeconds?: number
+      watch?: boolean
+    },
+  ) => completeMissingListFieldsAsyncIter({ kind: 'Deployment', apiVersion: 'apps/v1' }, paginationIterator<k8s.V1Deployment>(
+    wrap(continueToken => k8sAppsApi.listNamespacedDeployment(
+      namespace,
+      undefined,
+      undefined,
+      continueToken,
+      fieldSelector,
+      labelSelector,
+      undefined,
+      resourceVersion,
+      undefined,
+      timeoutSeconds,
+      watch,
+    )),
+  ))
+
+  const listReplicaSets = (
+    { namespace, fieldSelector, labelSelector, resourceVersion, timeoutSeconds, watch }: {
+      namespace: string
+      fieldSelector?: string
+      labelSelector?: string
+      resourceVersion?: string
+      timeoutSeconds?: number
+      watch?: boolean
+    },
+  ) => completeMissingListFieldsAsyncIter({ kind: 'ReplicaSet', apiVersion: 'apps/v1' }, paginationIterator<k8s.V1ReplicaSet>(
+    wrap(continueToken => k8sAppsApi.listNamespacedReplicaSet(
+      namespace,
+      undefined,
+      undefined,
+      continueToken,
+      fieldSelector,
+      labelSelector,
+      undefined,
+      resourceVersion,
+      undefined,
+      timeoutSeconds,
+      watch,
+    )),
+  ))
+
+  return {
+    listStatefulSets,
+    listDeployments,
+    listReplicaSets,
+  }
+}
+
+export const podHelpers = (
+  { k8sAppsApi, k8sApi, wrap }: {
+    k8sAppsApi: k8s.AppsV1Api
+    k8sApi: k8s.CoreV1Api
+    wrap: FuncWrapper
+  }
+) => {
+  const { listPods } = coreV1ApiHelpers(k8sApi, { wrap })
+  const { listReplicaSets } = appsV1ApiHelpers(k8sAppsApi, { wrap })
+
+  const listPodsForStatefulSet = (ss: k8s.V1StatefulSet) => {
+    const { name, namespace } = extractNameAndNamespace(ss)
+    const { matchLabels } = ensureDefined(extractDefined(extractDefined(ss, 'spec'), 'selector'), 'matchLabels')
+    const labelSelector = Object.entries(matchLabels).map(([k, v]) => `${k}=${v}`).join(',')
+    return asyncFilter<k8s.V1Pod>(
+      pod => Boolean(pod.metadata?.ownerReferences?.some(ref => ref.kind === 'StatefulSet' && ref.name === name)),
+      listPods({
+        namespace: namespace || '',
+        labelSelector,
+      }),
+    )
+  }
+
+  const findReadyPodForStatefulSet = async (
+    ss: k8s.V1StatefulSet,
+  ) => {
+    const pod = await asyncFind(readyPodPredicate, listPodsForStatefulSet(ss))
+    if (!pod) {
+      throw new StatefulSetNotReadyError(ss)
+    }
+    return pod
+  }
 
   const findReplicaSetForDeployment = async (deployment: Pick<k8s.V1Deployment, 'metadata'>) => {
-    const { name, namespace, annotations } = ensureDefined(extractDefined(deployment, 'metadata'), 'name', 'annotations', 'labels')
+    const { name, namespace, annotations } = ensureDefined(extractDefined(deployment, 'metadata'), 'name', 'namespace', 'annotations', 'labels')
     const revision = annotations['deployment.kubernetes.io/revision']
     if (!revision) {
       throw new DeploymentNotReadyError(deployment, 'NoRevision')
@@ -151,18 +288,23 @@ export default (
 
   const findReadyPodForDeployment = async (deployment: Pick<k8s.V1Deployment, 'metadata'>) => {
     const allPods = await asyncToArray(await listPodsForDeployment(deployment))
-    const pod = allPods.find(p => p.status?.conditions?.some(c => c.type === 'Ready' && c.status === 'True'))
+    const pod = allPods.find(readyPodPredicate)
     if (!pod) {
       throw new DeploymentNotReadyError(deployment, 'NoReadyPod')
     }
     return pod
   }
 
+  const findReadyPod = async (obj: Pick<k8s.V1Deployment, 'metadata' | 'kind'> | k8s.V1StatefulSet) => {
+    if (obj.kind === 'Deployment') {
+      return await findReadyPodForDeployment(obj as k8s.V1Deployment)
+    }
+    return await findReadyPodForStatefulSet(obj as k8s.V1StatefulSet)
+  }
+
   return {
-    listDeployments,
-    listReplicaSets,
-    listPods,
+    findReadyPodForStatefulSet,
     findReadyPodForDeployment,
-    listServices,
+    findReadyPod,
   }
 }

--- a/packages/driver-kube-pod/src/driver/client/metadata.test.ts
+++ b/packages/driver-kube-pod/src/driver/client/metadata.test.ts
@@ -32,7 +32,7 @@ describe('metadata', () => {
       const createName = () => envRandomName({ envId: repeat('a', 100), profileId: '1myprofile' })
       it('should truncate it to the correct length', () => {
         const name = createName()
-        expect(name).toHaveLength(53) // max name length with 10 chars spare
+        expect(name).toHaveLength(48) // max name length with 15 chars spare
         expect(name).toMatch(/^a1myprofile-a+-[a-z0-9]{5}$/)
       })
 

--- a/packages/driver-kube-pod/src/driver/common.ts
+++ b/packages/driver-kube-pod/src/driver/common.ts
@@ -2,16 +2,21 @@ import * as k8s from '@kubernetes/client-node'
 import { MachineBase, machineResourceType } from '@preevy/core'
 import { extractEnvId, extractInstance, extractName, extractNamespace } from './client/index.js'
 
-export type DeploymentMachine = MachineBase & {
-  deployment: k8s.V1Deployment
+export type KubernetesMachine<T extends k8s.KubernetesObject> = MachineBase & {
+  kubernetesObject: T
 }
+
+export type StatefulSetMachine = KubernetesMachine<k8s.V1StatefulSet>
+export type DeploymentMachine = KubernetesMachine<k8s.V1Deployment>
 
 export type ResourceType = typeof machineResourceType
 
-export const machineFromDeployment = (deployment: k8s.V1Deployment): DeploymentMachine & { envId: string } => ({
-  type: machineResourceType,
-  providerId: extractInstance(deployment),
-  locationDescription: `deployment/${extractName(deployment)} of namespace ${extractNamespace(deployment)}`,
-  envId: extractEnvId(deployment),
-  deployment,
-})
+export const k8sObjectToMachine = <T extends k8s.KubernetesObject>(
+  kubernetesObject: T,
+): KubernetesMachine<T> => ({
+    type: machineResourceType,
+    providerId: extractInstance(kubernetesObject),
+    locationDescription: `${kubernetesObject.kind}/${extractName(kubernetesObject)} of namespace ${extractNamespace(kubernetesObject)}`,
+    envId: extractEnvId(kubernetesObject),
+    kubernetesObject,
+  })

--- a/packages/driver-kube-pod/src/driver/creation-driver.ts
+++ b/packages/driver-kube-pod/src/driver/creation-driver.ts
@@ -1,29 +1,48 @@
+import fs from 'fs'
+import * as k8s from '@kubernetes/client-node'
 import { Flags, Interfaces } from '@oclif/core'
-import { MachineCreationDriver, MachineCreationDriverFactory, telemetryEmitter } from '@preevy/core'
+import { Logger, MachineCreationDriver, MachineCreationDriverFactory, telemetryEmitter } from '@preevy/core'
 import { pick } from 'lodash-es'
-import { DeploymentMachine, machineFromDeployment } from './common.js'
-import { DriverContext, clientFromConfiguration, machineConnection, flags as machineDriverFlags } from './driver.js'
+import { DeploymentMachine, ResourceType, StatefulSetMachine, k8sObjectToMachine } from './common.js'
+import { clientFromConfiguration, listMachines, machineConnection, flags as machineDriverFlags } from './driver.js'
+import { Client, CreationClient, kubeCreationClient, loadKubeConfig } from './client/index.js'
+import { DEFAULT_TEMPLATE, packageJson } from '../static.js'
 
 export const flags = {
   ...machineDriverFlags,
+  template: Flags.string({
+    description: 'Path to custom resources template file (will use default template if not specified)',
+    required: false,
+  }),
   'server-side-apply': Flags.boolean({
     description: 'Use server side apply to create Kubernetes resources',
     default: true,
     required: false,
     allowNo: true,
   }),
+  'storage-class': Flags.string({
+    description: 'Storage class to use for Pod data volume',
+    required: false,
+  }),
+  'storage-size': Flags.custom<number>({
+    description: 'Size of Pod data volume in GiB',
+    required: false,
+    default: 5,
+    parse: async v => Number(v),
+  })(),
 } as const
 
 export type MachineCreationFlagTypes = Omit<Interfaces.InferredFlags<typeof flags>, 'json'>
 
-type MachineCreationDriverContext = DriverContext & {
-  serverSideApply: boolean
-  metadata: MachineCreationFlagTypes
-}
-
 const machineCreationDriver = (
-  { client, serverSideApply, log, metadata }: MachineCreationDriverContext,
-): MachineCreationDriver<DeploymentMachine> => ({
+  { client, creationClient, serverSideApply, log, metadata }: {
+    log: Logger
+    serverSideApply: boolean
+    metadata: MachineCreationFlagTypes
+    client: Client
+    creationClient: CreationClient
+  },
+): MachineCreationDriver<StatefulSetMachine | DeploymentMachine, ResourceType> => ({
   metadata,
   createMachine: async ({ envId }) => {
     const startTime = new Date().getTime()
@@ -33,8 +52,8 @@ const machineCreationDriver = (
       fromSnapshot: true,
       result: (async () => {
         log.debug('create machine', { envId, serverSideApply })
-        const deployment = await client.createEnv(envId, { serverSideApply })
-        const machine = machineFromDeployment(deployment)
+        const statefulSet = await creationClient.createEnv(envId, { serverSideApply })
+        const machine = k8sObjectToMachine(statefulSet)
         telemetryEmitter().capture('kube-pod create machine end', { elapsed_sec: (new Date().getTime() - startTime) / 1000 })
         const connection = await machineConnection(client, machine, log)
         return { machine, connection }
@@ -44,33 +63,66 @@ const machineCreationDriver = (
 
   ensureMachineSnapshot: async () => undefined,
   getMachineAndSpecDiff: async ({ envId }) => {
-    const deployment = await client.findMostRecentDeployment({ envId, deleted: false })
-    if (!deployment) {
+    const obj = await client.findEnvObject({ envId, deleted: false })
+    if (!obj) {
       return undefined
     }
 
-    const deploymentHash = client.extractTemplateHash(deployment)
-    const machine = machineFromDeployment(deployment)
-    const templateHash = await client.calcTemplateHash({ instance: machine.providerId })
+    const deployedHash = creationClient.extractTemplateHash(obj)
+    const machine = k8sObjectToMachine(obj)
+    const templateHash = await creationClient.calcTemplateHash({ instance: machine.providerId })
 
     return {
-      ...machineFromDeployment(deployment),
-      specDiff: deploymentHash !== templateHash
-        ? [{ name: 'template', old: deploymentHash, new: templateHash }]
+      ...machine,
+      specDiff: deployedHash !== templateHash
+        ? [{ name: 'template', old: deployedHash, new: templateHash }]
         : [],
     }
   },
+  listDeletableResources: () => listMachines({ client }),
+
+  deleteResources: async (wait, ...resources) => {
+    await Promise.all(resources.map(({ type, providerId }) => {
+      if (type === 'machine') {
+        return creationClient.deleteEnv(providerId, { wait })
+      }
+      throw new Error(`Unknown resource type: "${type}"`)
+    }))
+  },
+
+})
+
+type FlagTypes = Omit<Interfaces.InferredFlags<typeof flags>, 'json'>
+
+const creationClientFromConfiguration = ({ flags: f, profileId, log, kc }: {
+  flags: FlagTypes
+  profileId: string
+  log: Logger
+  kc: k8s.KubeConfig
+}) => kubeCreationClient({
+  log,
+  namespace: f.namespace,
+  kc,
+  profileId,
+  package: packageJson,
+  template: fs.readFileSync(f.template || DEFAULT_TEMPLATE, 'utf-8'),
+  storageClass: f['storage-class'],
+  storageSize: f['storage-size'],
 })
 
 export const factory: MachineCreationDriverFactory<
   Interfaces.InferredFlags<typeof flags>,
-  DeploymentMachine
-> = ({ flags: f, profile: { id: profileId }, log, debug }) => machineCreationDriver({
-  metadata: pick(f, Object.keys(machineDriverFlags)) as MachineCreationFlagTypes, // filter out non-driver flags
-  log,
-  debug,
-  client: clientFromConfiguration({ log, flags: f, profileId }),
-  serverSideApply: f['server-side-apply'],
-})
+  StatefulSetMachine | DeploymentMachine,
+  ResourceType
+> = ({ flags: f, profile: { id: profileId }, log }) => {
+  const kc = loadKubeConfig(f)
+  return machineCreationDriver({
+    metadata: pick(f, Object.keys(machineDriverFlags)) as MachineCreationFlagTypes, // filter out non-driver flags
+    log,
+    client: clientFromConfiguration({ log, flags: f, profileId, kc }),
+    serverSideApply: f['server-side-apply'],
+    creationClient: creationClientFromConfiguration({ log, flags: f, profileId, kc }),
+  })
+}
 
 export default machineCreationDriver

--- a/packages/driver-kube-pod/src/driver/index.ts
+++ b/packages/driver-kube-pod/src/driver/index.ts
@@ -2,7 +2,7 @@ import { flags, factory } from './driver.js'
 import { flags as machineCreationFlags, factory as machineCreationFactory } from './creation-driver.js'
 import { inquireFlags } from './questions.js'
 
-export type { DeploymentMachine, ResourceType } from './common.js'
+export type { StatefulSetMachine, DeploymentMachine, ResourceType } from './common.js'
 export type { MachineCreationFlagTypes } from './creation-driver.js'
 
 export default {

--- a/packages/driver-kube-pod/src/driver/questions.ts
+++ b/packages/driver-kube-pod/src/driver/questions.ts
@@ -1,14 +1,38 @@
 import * as inquirer from '@inquirer/prompts'
+import * as k8s from '@kubernetes/client-node'
+import { Logger, withSpinner } from '@preevy/core'
+import { asyncToArray } from 'iter-tools-es'
 import { MachineCreationFlagTypes, flags } from './creation-driver.js'
-import { loadKubeConfig } from './client/index.js'
+import { extractName, loadKubeConfig } from './client/index.js'
+import { storageV1ApiHelpers as createStorageV1ApiHelpers } from './client/k8s-helpers.js'
+import { logError } from './client/log-error.js'
 
-export const inquireFlags = async (): Promise<Partial<MachineCreationFlagTypes>> => {
+export const inquireStorageClass = async (kc: k8s.KubeConfig, { log }: { log: Logger }) => {
+  const wrap = logError(log)
+  const storageHelpers = createStorageV1ApiHelpers(kc.makeApiClient(k8s.StorageV1Api), { wrap })
+  const availableStorageClasses = await withSpinner(
+    () => asyncToArray(storageHelpers.listStorageClasses({ })),
+    { text: 'Loading storage classes...' },
+  )
+
+  if (!availableStorageClasses.length) {
+    return undefined
+  }
+  const storageClassNames = availableStorageClasses.map(extractName)
+  return await inquirer.select({
+    message: flags['storage-class'].description as string,
+    choices: [{ name: '(default)', value: undefined }, new inquirer.Separator(), ...storageClassNames.map(c => ({ value: c }))],
+    default: undefined,
+  })
+}
+
+export const inquireFlags = async ({ log }: { log: Logger }): Promise<Partial<MachineCreationFlagTypes>> => {
   const namespace = await inquirer.input({
     default: flags.namespace.default as string,
     message: flags.namespace.description as string,
   })
 
-  const kc = loadKubeConfig() // will read from KUBECONFIG env var as well
+  const kc = loadKubeConfig({}) // will read from KUBECONFIG env var as well
   const contextChoices = [
     { name: 'Default: use default context at runtime', value: undefined },
     new inquirer.Separator(),
@@ -20,8 +44,18 @@ export const inquireFlags = async (): Promise<Partial<MachineCreationFlagTypes>>
     message: flags.context.description as string,
   })
 
+  const storageClass = await inquireStorageClass(kc, { log })
+
+  const storageSize = Number(await inquirer.input({
+    message: flags['storage-size'].description as string,
+    default: String(flags['storage-size'].default),
+    validate: value => (Number(value) > 0 ? true : 'Please enter a positive number'),
+  }))
+
   return {
     ...(namespace && namespace !== flags.namespace.default) ? { namespace } : undefined,
     ...(context && context !== flags.context.default) ? { context } : undefined,
+    ...(storageClass && storageClass !== flags['storage-class'].default) ? { 'storage-class': storageClass } : undefined,
+    ...(storageSize && storageSize !== flags['storage-size'].default) ? { 'storage-size': storageSize } : undefined,
   }
 }

--- a/packages/driver-kube-pod/static/default-template.yaml.njk
+++ b/packages/driver-kube-pod/static/default-template.yaml.njk
@@ -14,26 +14,30 @@ metadata:
 data:
   daemon.json: |
     {
-      "tls": false
+      "tls": false,
+      "data-root": "/data/docker"
     }
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ id }}
   namespace: {{ namespace }}
   labels:
-    app: preevy-{{ id }}
     app.kubernetes.io/component: docker-host
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: preevy-{{ id }}
+      {% for k, v in labels %}
+      {{ k }}: {{ v }}
+      {% endfor %}
   template:
     metadata:
       labels:
-        app: preevy-{{ id }}
+        {% for k, v in labels %}
+        {{ k }}: {{ v }}
+        {% endfor %}
     spec:
       serviceAccountName: {{ id }}-sa
       containers:
@@ -43,15 +47,29 @@ spec:
           privileged: true
         command: ["dockerd", "--host=tcp://0.0.0.0:2375", "--host=unix:///var/run/docker.sock"]
         volumeMounts:
-        - mountPath: /etc/docker
-          name: docker-config
-
-
+        - name: docker-config
+          mountPath: /etc/docker
+        - name: data
+          mountPath: /data
       volumes:
       - name: docker-config
         configMap:
           name: {{ id }}-dc
-
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      labels:
+        {% for k, v in labels %}
+        {{ k }}: {{ v }}
+        {% endfor %}
+    spec:
+      accessModes: ["ReadWriteOnce"]
+{% if storageClass %}
+      storageClassName: "{{ storageClass }}"
+{% endif %}
+      resources:
+        requests:
+          storage: {{ storageSize }}Gi
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
new environments now use a StatefulSet definition which [dynamically provisions](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) a persistent volume. Cluster must have a default StorageClass defined.
