### PR TITLE
kube driver: change default dind image to alpine

### DIFF
--- a/packages/driver-kube-pod/static/default-template.yaml.njk
+++ b/packages/driver-kube-pod/static/default-template.yaml.njk
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: {{ id }}-sa
       containers:
       - name: docker
-        image: docker:24-dind
+        image: docker:24.0.7-dind-alpine3.18
         securityContext:
           privileged: true
         command: ["dockerd", "--host=tcp://0.0.0.0:2375", "--host=unix:///var/run/docker.sock"]


### PR DESCRIPTION
fix errors while starting the Docker server on GKE nodes:
```
failed to start daemon: Error initializing network controller: error creating default bridge network: Failed to Setup IP tables: Unable to enable NAT rule:  (iptables failed: iptables --wait -t nat -I POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE: Warning: Extension MASQUERADE revision 0 not supported, missing kernel module?
iptables v1.8.10 (nf_tables):  CHAIN_ADD failed (No such file or directory): chain POSTROUTING
 (exit status 4))
```