### PR TITLE
Add CI Provider for Bitbucket Pipelines

### DIFF
--- a/packages/core/src/ci-providers/bitbucket-pipelines.ts
+++ b/packages/core/src/ci-providers/bitbucket-pipelines.ts
@@ -1,0 +1,15 @@
+import { CiProvider } from './base.js'
+import { stringOrUndefinedToNumber } from './common.js'
+
+// https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+export const bitbucketPipelinesCiProvider = (): CiProvider => ({
+  name: 'Bitbucket Pipelines',
+  id: 'bitbucket',
+  currentlyRunningInProvider: () => Boolean(process.env.CI && process.env.BITBUCKET_BUILD_NUMBER),
+  branchName: () => process.env.BITBUCKET_BRANCH || process.env.BITBUCKET_TAG,
+  gitCommit: () => process.env.BITBUCKET_COMMIT as string,
+  pullRequestNumber: () => stringOrUndefinedToNumber(
+    process.env.BITBUCKET_PR_ID
+  ),
+  repoUrl: () => process.env.BITBUCKET_GIT_HTTP_ORIGIN,
+})

--- a/packages/core/src/ci-providers/index.ts
+++ b/packages/core/src/ci-providers/index.ts
@@ -4,6 +4,7 @@ import { circleCiProvider } from './circle.js'
 import { githubActionsCiProvider } from './github-actions.js'
 import { gitlabActionsCiProvider } from './gitlab.js'
 import { travisCiProvider } from './travis.js'
+import { bitbucketPipelinesCiProvider } from './bitbucket-pipelines.js'
 
 export const ciProviders = {
   githubActions: githubActionsCiProvider(),
@@ -11,6 +12,7 @@ export const ciProviders = {
   travis: travisCiProvider(),
   circle: circleCiProvider(),
   azurePipelines: azurePipelinesCiProvider(),
+  bitbucketPipelines: bitbucketPipelinesCiProvider()
 }
 
 export const detectCiProvider = (): CiProvider | undefined => Object.values(ciProviders)


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to Preevy! 🎉 -->

<!-- Please fill in the below placeholders -->

This adds Bitbucket Pipelines as a CI provider.
I copied the code from one of the other providers, but didn't see any existing tests for this (but it's a quite straightforward change I guess)

## This is a
- [x] Feature

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

- [x] I have used Preevy for a while and am familiar with the function it provides.

If this is a bug fix or feature:

- [ ] I tested the proposed change on my cloud provider: **Please specify which provider**
- [ ] I tested the proposed change on a local Kubernetes cluster.

Both are n/a
