### PR TITLE
feat: Bump AWS Lightsail blueprint to ubuntu_24_04

### DIFF
--- a/packages/driver-lightsail/src/driver/client.ts
+++ b/packages/driver-lightsail/src/driver/client.ts
@@ -189,7 +189,7 @@ const client = ({
           ...commonArgs,
           instanceSnapshotName,
         })
-        : ls.createInstances({ ...commonArgs, blueprintId: 'ubuntu_20_04' })
+        : ls.createInstances({ ...commonArgs, blueprintId: 'ubuntu_24_04' })
 
       await waitUntilAllOperationsSucceed(
         { client: lsClient, maxWaitTime: 150 },

--- a/packages/driver-lightsail/src/driver/tags.ts
+++ b/packages/driver-lightsail/src/driver/tags.ts
@@ -1,7 +1,7 @@
 import { inspect } from 'util'
 import { extractDefined } from '@preevy/core'
 
-export const CURRENT_MACHINE_VERSION = 'm-2023-08-02'
+export const CURRENT_MACHINE_VERSION = 'm-2025-04-04'
 
 export const TAGS = {
   PROFILE_ID: 'preevy-profile-id',


### PR DESCRIPTION
## This is a

- [ ] Bug fix
- [X] Feature
- [ ] Doc improvement

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

- [X] I have used Preevy for a while and am familiar with the function it provides.

If this is a bug fix or feature:

- [X] I tested the proposed change on my cloud provider: AWS Lightsail
- [ ] I tested the proposed change on a local Kubernetes cluster.

AWS warns about the End of Standard Support for `ubuntu_20_04` blueprint instances. This PR bumps the blueprint id to the current/recommended  value `ubuntu_24_04`.

![Screenshot 2025-04-03 at 2 55 44 PM](https://github.com/user-attachments/assets/a0ba3608-b1e2-474e-a926-4e4a5a940a8f)
