### PR TITLE
fix: use `docker compose config` instead of `convert` which is now deprecated

### DIFF
--- a/packages/core/src/compose/client.ts
+++ b/packages/core/src/compose/client.ts
@@ -63,7 +63,7 @@ const composeClient = (
     throw e
   })
 
-  const getModel = async (services: string[] = []) => yaml.parse(await execComposeCommand(['convert', ...services])) as ComposeModel
+  const getModel = async (services: string[] = []) => yaml.parse(await execComposeCommand(['config', ...services])) as ComposeModel
 
   return {
     getModel,


### PR DESCRIPTION
### **User description**
fixes #576


___

### **PR Type**
Bug fix


___

### **Description**
- Replace deprecated `docker compose convert` with `config` command

- Fix compatibility with Docker Compose v2.36.0+ versions


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Docker Compose Client"] -- "executes" --> B["config command"]
  B -- "replaces" --> C["deprecated convert command"]
  C -- "fixes compatibility" --> D["Docker Compose v2.36.0+"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.ts</strong><dd><code>Replace deprecated convert with config command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/compose/client.ts

<li>Replace <code>convert</code> with <code>config</code> in execComposeCommand call<br> <li> Update getModel function to use supported Docker Compose command


</details>


  </td>
  <td><a href="https://github.com/livecycle/preevy/pull/577/files#diff-5f05f7b9084ebe4d0b236491092b0331044f801634799ed097ecce3b0a8422ac">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>